### PR TITLE
Task/COOKS-257: Redirect to onboarding page if setup not complete.

### DIFF
--- a/conf/cms/secrets.sample.py
+++ b/conf/cms/secrets.sample.py
@@ -1,4 +1,4 @@
-LOGIN_REDIRECT_URL = "/demographics"
+LOGIN_REDIRECT_URL = "/analytics"
 
 ########################
 # DJANGO SETTINGS

--- a/conf/cms/secrets.sample.py
+++ b/conf/cms/secrets.sample.py
@@ -1,6 +1,4 @@
-# After https://jira.tacc.utexas.edu/browse/COOKS-21, then should
-#be route to frontend: "/protx/demographics"
-LOGIN_REDIRECT_URL = "/protx/api/maltreatment"
+LOGIN_REDIRECT_URL = "/demographics"
 
 ########################
 # DJANGO SETTINGS

--- a/conf/portal/settings_custom.py
+++ b/conf/portal/settings_custom.py
@@ -170,5 +170,5 @@ _WORKBENCH_SETTINGS = {
     "makePublic": False,
     "hideApps": True,
     "hideDataFiles": True,
-    "onboardingCompleteRedirect": '/protx/'
+    "onboardingCompleteRedirect": '/analytics'
 }

--- a/protx-client/src/utils/fetchUtil.js
+++ b/protx-client/src/utils/fetchUtil.js
@@ -8,10 +8,6 @@ export class FetchError extends Error {
   }
 }
 
-function redirectToOnboarding() {
-  window.location.replace(`${window.location.origin}/workbench/onboarding`);
-}
-
 export async function fetchUtil({ url, params, ...options }) {
   const request = new URL(url, window.location.origin);
   await Object.entries(params || {}).forEach(([key, val]) =>
@@ -30,11 +26,7 @@ export async function fetchUtil({ url, params, ...options }) {
   const response = await fetch(request, fetchParams);
   const json = await response.json();
   if (!response.ok) {
-    if (response.status === 403 && json.message === 'onboarding incomplete') {
-      redirectToOnboarding();
-    } else {
-      throw new FetchError(json, response);
-    }
+    throw new FetchError(json, response);
   }
 
   return json;

--- a/protx-client/src/utils/fetchUtil.js
+++ b/protx-client/src/utils/fetchUtil.js
@@ -8,6 +8,10 @@ export class FetchError extends Error {
   }
 }
 
+function redirectToOnboarding() {
+  window.location.replace(`${window.location.origin}/workbench/onboarding`);
+}
+
 export async function fetchUtil({ url, params, ...options }) {
   const request = new URL(url, window.location.origin);
   await Object.entries(params || {}).forEach(([key, val]) =>
@@ -26,7 +30,11 @@ export async function fetchUtil({ url, params, ...options }) {
   const response = await fetch(request, fetchParams);
   const json = await response.json();
   if (!response.ok) {
-    throw new FetchError(json, response);
+    if (response.status === 403 && json.message === 'onboarding incomplete') {
+      redirectToOnboarding();
+    } else {
+      throw new FetchError(json, response);
+    }
   }
 
   return json;

--- a/protx/app.py
+++ b/protx/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template
 from flask_restx import Api
 from protx.api import api as protx_api
-from protx.decorators import onboarded_user_required
+from protx.decorators import onboarded_user_setup_complete
 import logging
 import os
 
@@ -20,6 +20,6 @@ api.add_namespace(protx_api, path="/protx/api")
 
 
 @app.route("/protx/dash/<path:path>")
-@onboarded_user_required
+@onboarded_user_setup_complete
 def index(path=None):
     return render_template(template)

--- a/protx/app.py
+++ b/protx/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template
 from flask_restx import Api
 from protx.api import api as protx_api
+from protx.decorators import onboarded_user_required
 import logging
 
 app = Flask(__name__)
@@ -13,6 +14,7 @@ api.add_namespace(protx_api, path="/protx/api")
 
 
 @app.route("/protx/dash/<path:path>")
+@onboarded_user_required
 def index(path=None):
     # TODO: Render alternate template for the compiled bundle.
     # https://jira.tacc.utexas.edu/browse/COOKS-256

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -3,7 +3,7 @@ from werkzeug.exceptions import Forbidden
 from diskcache import Cache
 import os
 import logging
-from flask import request, redirect, url_for
+from flask import request, redirect
 import requests
 
 logger = logging.getLogger(__name__)

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -3,12 +3,41 @@ from werkzeug.exceptions import Forbidden
 from diskcache import Cache
 import os
 import logging
-from flask import request, redirect
+from flask import request, redirect, url_for
 import requests
 
 logger = logging.getLogger(__name__)
 
 cache = Cache("database_cache")
+
+def is_setup_complete(function, redirect_onboarding):
+    try:
+        # making request directly to core django. alternatively, we could
+        # make the request to the request.get_host() (but then a bit
+        # tricky if it is local development and accessing cep.dev)
+        r = requests.get("http://django:6000/api/workbench/", cookies=request.cookies)
+        r.raise_for_status()
+        json_response = r.json()
+        if json_response['response']['setupComplete']:
+            return function(*args, **kwargs)
+        else:
+            if redirect_onboarding:
+                redirect_url = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
+                return redirect(redirect_url + '/workbench/onboarding')
+            else:
+                raise Forbidden
+
+    except Exception as e:
+        logger.error(e)
+        raise Forbidden
+
+def onboarded_user_setup_complete(function):
+    """Decorator requires user to have setup_completed or redirects.
+    """
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        return is_setup_complete(function, True)
+    return wrapper
 
 
 def onboarded_user_required(function):
@@ -16,24 +45,7 @@ def onboarded_user_required(function):
     """
     @wraps(function)
     def wrapper(*args, **kwargs):
-        try:
-            # making request directly to core django. alternatively, we could
-            # make the request to the request.get_host() (but then a bit
-            # tricky if it is local development and accessing cep.dev)
-            r = requests.get("http://django:6000/api/workbench/", cookies=request.cookies)
-            r.raise_for_status()
-            json_response = r.json()
-            redirect_url = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
-
-            if json_response['response']['setupComplete']:
-                return function(*args, **kwargs)
-            else:
-                return redirect(redirect_url + '/workbench/onboarding')
-        except Exception as e:
-            logger.error(e)
-            raise Forbidden
-        else:
-            return function(*args, **kwargs)
+        return is_setup_complete(function, False)
     return wrapper
 
 

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -27,14 +27,14 @@ def onboarded_user_setup_complete(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         try:
-            if is_setup_complete():
-                return function(*args, **kwargs)
-            else:
+            if not is_setup_complete():
                 redirect_url = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
                 return redirect(redirect_url + '/workbench/onboarding')
         except Exception as e:
             logger.error(e)
             raise Forbidden
+        else:
+          return function(*args, **kwargs)
     return wrapper
 
 
@@ -44,13 +44,13 @@ def onboarded_user_required(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         try:
-            if is_setup_complete():
-                return function(*args, **kwargs)
-            else:
+            if not is_setup_complete():
                 raise Forbidden
         except Exception as e:
             logger.error(e)
             raise Forbidden
+        else:
+          return function(*args, **kwargs)
     return wrapper
 
 

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -26,8 +26,9 @@ def onboarded_user_required(function):
             if json_response['response']['setupComplete']:
                 return function(*args, **kwargs)
             else:
-                raise Forbidden
-            return function(*args, **kwargs)
+                return {
+                    "message": "onboarding incomplete"
+                }, 403
         except Exception as e:
             logger.info(e)
             raise Forbidden

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 cache = Cache("database_cache")
 
-def is_setup_complete(function, redirect_onboarding):
+def is_setup_complete(function, redirect_onboarding, *args, **kwargs):
     try:
         # making request directly to core django. alternatively, we could
         # make the request to the request.get_host() (but then a bit
@@ -36,7 +36,7 @@ def onboarded_user_setup_complete(function):
     """
     @wraps(function)
     def wrapper(*args, **kwargs):
-        return is_setup_complete(function, True)
+        return is_setup_complete(function, True, *args, **kwargs)
     return wrapper
 
 
@@ -45,7 +45,7 @@ def onboarded_user_required(function):
     """
     @wraps(function)
     def wrapper(*args, **kwargs):
-        return is_setup_complete(function, False)
+        return is_setup_complete(function, False, *args, **kwargs)
     return wrapper
 
 

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -31,6 +31,7 @@ def onboarded_user_setup_complete(function):
                 redirect_url = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
                 return redirect(redirect_url + '/workbench/onboarding')
         except Exception as e:
+            # User isn't logged in which is unexpected as pages (which contain this SPA as an iframe) are controlled by CMS which should require a login
             logger.error(e)
             raise Forbidden
         else:

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -34,7 +34,7 @@ def onboarded_user_setup_complete(function):
             logger.error(e)
             raise Forbidden
         else:
-          return function(*args, **kwargs)
+            return function(*args, **kwargs)
     return wrapper
 
 
@@ -50,14 +50,14 @@ def onboarded_user_required(function):
             logger.error(e)
             raise Forbidden
         else:
-          return function(*args, **kwargs)
+            return function(*args, **kwargs)
     return wrapper
 
 
 def check_db_timestamp_and_cache_validity(db_file):
     """ Check if cache should be updated as data db file has been modified
 
-        :param str db_file: path to file where results are derived.
+    :param str db_file: path to file where results are derived.
     """
     def decorator(f):
         @wraps(f)

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -17,6 +17,9 @@ def onboarded_user_required(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         try:
+            # making request directly to core django. alternatively, we could
+            # make the request to the request.get_host() (but then a bit
+            # tricky if it is local development and accessing cep.dev)
             r = requests.get("http://django:6000/api/workbench/", cookies=request.cookies)
             r.raise_for_status()
             json_response = r.json()


### PR DESCRIPTION
## Overview: ##
Redirect to `workbench/onboarding` if user's onboarding is incomplete.

## Related Jira tickets: ##

* [COOKS-257](https://jira.tacc.utexas.edu/browse/COOKS-257)

## Summary of Changes: ##
Added a message in the onboarding check decorator and handled it in frontend.

## Testing Steps: ##
1. Contrive an incomplete user onboarding state.
2. Ensure that protx routes redirect to `workbench/onboarding`.

## UI Photos:

## Notes: ##
