### PR TITLE
Task/COOKS-259: Fix missing globe icon for protx-dashboard

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -122,6 +122,10 @@ http {
             alias /var/www/portal/portal/static/favicon.ico;
         }
 
+        location /src/fonts {
+            alias /var/www/portal/protx-client/src/fonts;
+        }
+
         ## Include any custom location directives
         include /etc/nginx/conf.d/*.location.conf;
     }


### PR DESCRIPTION
## Overview: ##
Restores globe icon for protx-dashboard

## Related Jira tickets: ##

* [COOKS-259](https://jira.tacc.utexas.edu/browse/COOKS-259)

## Summary of Changes: ##
Added nginx configuration for Cortal font.

## Testing Steps: ##
1. Ensure that you see the globe icon in the description and in the map.

## UI Photos:

## Notes: ##
