### PR TITLE
Task/cooks 276 add makefile

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-CMS_IMAGE=taccwma/protx-cms
-PORTAL_IMAGE=taccwma/core-portal
-CMS_TAG=5a09f44
-PORTAL_TAG=be3fea2
-PROTX_GEOSPATIAL_TAG=334920b

--- a/.env
+++ b/.env
@@ -13,9 +13,7 @@ CMS_TAG=5a09f44
 PORTAL_IMAGE=taccwma/core-portal
 PORTAL_TAG=be3fea2
 
-# When testing published images:
+# When testing published images, these would be used but see docker-compose.yml as it is configured to build its own image and use a volume of local source code would would need to be disabled
 PROTX_DASHBOARD_IMAGE=taccwma/protx-dashboard
-# When testing local images:
-# PROTX_DASHBOARD_IMAGE=protx-dashboard
 PROTX_DASHBOARD_TAG=7800601
 PROTX_GEOSPATIAL_TAG=334920b

--- a/.env
+++ b/.env
@@ -1,0 +1,16 @@
+# CAMINO_VERSION=v2.4.0
+# CAMINO_HOME=/opt/portal/Camino
+# COMPOSE_FILE=docker-compose.pprd.override.yml
+# COMPOSE_PROJECT_NAME=camino
+# CUSTOM_SETTINGS_PORTAL=pprd.settings_custom.py
+# CUSTOM_SETTINGS_CMS=pprd.cms.settings_local.py
+# SSH_HOST=portal@pprd.protx.tacc.utexas.edu
+CMS_IMAGE=taccwma/protx-cms
+CMS_TAG=5a09f44
+PORTAL_IMAGE=taccwma/core-portal
+PORTAL_TAG=be3fea2
+# PROTX_DASHBOARD_IMAGE=taccwma/protx-dashboard
+# For local testing of images:
+PROTX_DASHBOARD_IMAGE=protx-dashboard
+PROTX_DASHBOARD_TAG=78006013
+PROTX_GEOSPATIAL_TAG=334920b

--- a/.env
+++ b/.env
@@ -14,8 +14,8 @@ PORTAL_IMAGE=taccwma/core-portal
 PORTAL_TAG=be3fea2
 
 # When testing published images:
-# PROTX_DASHBOARD_IMAGE=taccwma/protx-dashboard
+PROTX_DASHBOARD_IMAGE=taccwma/protx-dashboard
 # When testing local images:
-PROTX_DASHBOARD_IMAGE=protx-dashboard
-PROTX_DASHBOARD_TAG=1ab272ca
+# PROTX_DASHBOARD_IMAGE=protx-dashboard
+PROTX_DASHBOARD_TAG=7800601
 PROTX_GEOSPATIAL_TAG=334920b

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+# These settings are unused in local dev.
 # CAMINO_VERSION=v2.4.0
 # CAMINO_HOME=/opt/portal/Camino
 # COMPOSE_FILE=docker-compose.pprd.override.yml
@@ -5,12 +6,16 @@
 # CUSTOM_SETTINGS_PORTAL=pprd.settings_custom.py
 # CUSTOM_SETTINGS_CMS=pprd.cms.settings_local.py
 # SSH_HOST=portal@pprd.protx.tacc.utexas.edu
+
 CMS_IMAGE=taccwma/protx-cms
 CMS_TAG=5a09f44
+
 PORTAL_IMAGE=taccwma/core-portal
 PORTAL_TAG=be3fea2
+
+# When testing published images:
 # PROTX_DASHBOARD_IMAGE=taccwma/protx-dashboard
-# For local testing of images:
+# When testing local images:
 PROTX_DASHBOARD_IMAGE=protx-dashboard
-PROTX_DASHBOARD_TAG=78006013
+PROTX_DASHBOARD_TAG=1ab272ca
 PROTX_GEOSPATIAL_TAG=334920b

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ nohup.out
 
 docker_repo.var
 
-#ignore portal.env
-.env
-portal.env
 
 # no node modules
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ nohup.out
 *settings_custom.py
 *settings_local.py
 
+docker_repo.var
+
+#ignore portal.env
+.env
+portal.env
+
 # no node modules
 node_modules/
 
@@ -47,8 +53,6 @@ target/
 /server/conf/docker/logs.txt
 
 # Custom
-
-docker_repo.var
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ target/
 
 # Custom
 
+docker_repo.var
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 FROM python:3.9-slim
 
-RUN apt-get update && apt-get install -y curl
+LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
 
 ENV POETRY_VERSION=1.1.13
 ENV POETRY_HOME=/opt/poetry
 ENV PATH="$POETRY_HOME/bin:$PATH"
+ENV PYTHONPATH "${PYTHONPATH}:/app"
+
+RUN apt-get update && apt-get install -y curl
 
 RUN mkdir /app
 WORKDIR /app/protx
 
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+
 RUN poetry config virtualenvs.create false
 
 COPY pyproject.toml poetry.lock ./
@@ -17,11 +21,9 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install
 
 COPY ./protx /app/protx
-ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 # TODO not needed except to make build step work (as needed in local dev)
 COPY ./conf/certificates /app/conf/certificates
-
 
 # Install node 16.x and build client for production/staging
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
+DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
+DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
+DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+
+####
+# `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
+DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD)
+
+.PHONY: info
+info:
+	@echo $(DOCKERHUB_REPO)
+	@echo $(DOCKER_TAG)
+	@echo $(DOCKER_IMAGE)
+	@echo $(DOCKER_IMAGE_LATEST)
+	@echo $(DOCKER_IMAGE_BRANCH)
+
+.PHONY: build
+build:
+	docker-compose -f docker-compose.yml build
+
+.PHONY: build-full
+build-full:
+	docker build -t $(DOCKER_IMAGE) -f Dockerfile .
+
+.PHONY: publish
+publish:
+	docker push $(DOCKER_IMAGE)
+	# docker push $(DOCKER_IMAGE_BRANCH)
+
+.PHONY: publish-latest
+publish-latest:
+	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE_LATEST)
+	docker push $(DOCKER_IMAGE_LATEST)
+
+.PHONY: start
+start:
+	docker-compose -f docker-compose.yml up
+
+.PHONY: stop
+stop:
+	docker-compose -f docker-compose.yml down
+
+.PHONY: stop-full
+stop-v:
+	docker-compose -f docker-compose.yml down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,16 +142,19 @@ services:
     container_name: core_portal_workers
 
   protx:
-    image: ${PROTX_DASHBOARD_IMAGE}:${PROTX_DASHBOARD_TAG}
-    # build:
-    #   context: .
-    #   dockerfile: ./Dockerfile
+    # Uncomment this line to use an image defined in .env file.
+    # image: ${PROTX_DASHBOARD_IMAGE}:${PROTX_DASHBOARD_TAG}
+    # Comment out the build block if using an image.
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     volumes:
-      # - ./protx:/app/protx
       - ~/protx-data:/protx-data
-      # - type: volume
-      #   source: protx_app_distribution
-      #   target: /app/protx-client/dist/
+      # Comment out these two volumes if using an image.
+      - ./protx:/app/protx
+      - type: volume
+        source: protx_app_distribution
+        target: /app/protx-client/dist/
     ports:
       - 8000:8000
     dns:
@@ -159,7 +162,7 @@ services:
       - 8.8.4.4
     environment:
       - FLASK_APP=/app/protx/app.py
-      - FLASK_ENV=production  #development
+      - FLASK_ENV=development
       - USE_DEV_CLIENT=false #  if false, use the pre-built-container client.
     stdin_open: true
     tty: true
@@ -187,4 +190,4 @@ volumes:
   core_portal_postgres_data:
   core_cms_postgres_data:
   protx_geospatial_data:
-  protx_app_distribution: # can be used for testing client built-in-container locally
+  protx_app_distribution: # Can be used for testing client built-in-container locally. Comment out if testing an image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 # The .env file sets ENVVARS for the Docker CLI used by this compose file.
+
 ---
 version: "3"
 services:
@@ -14,38 +15,6 @@ services:
     depends_on:
       - postgrescms
 
-  nginx:
-    image: nginx
-    volumes:
-      - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./conf/nginx/protx.location.conf:/etc/nginx/conf.d/protx.location.conf
-      - ./conf/nginx/data.location.conf:/etc/nginx/conf.d/data.location.conf
-      - ./conf/nginx/assets.location.conf:/etc/nginx/conf.d/assets.location.conf
-      - ./conf/uwsgi/uwsgi_params:/etc/nginx/uwsgi_params
-      - ./conf/certificates/dhparam.pem:/etc/ssl/dhparam.pem
-      - ./conf/certificates/cep.dev.crt:/etc/ssl/certs/portal.cer
-      - ./conf/certificates/cep.dev.key/:/etc/ssl/private/portal.key
-      - /var/www/portal/cms/static:/var/www/portal/cms/static
-      - /var/www/portal/cms/media:/var/www/portal/cms/media
-      - /var/www/portal/portal/media:/var/www/portal/portal/media
-      - /var/www/portal/portal/static:/var/www/portal/portal/static
-      - protx_geospatial_data:/protx-data/static
-      - ./protx-client:/var/www/portal/protx-client
-      - protx_app_distribution:/protx-app-distribution
-    ports:
-      - 80:80
-      - 443:443
-    container_name: core_portal_nginx
-    depends_on:
-      - cms
-      - django
-
-  memcached:
-    image: memcached:latest
-    command: ["-m", "1024m"]
-    container_name: core_portal_memcached
-    restart: always
-
   redis:
     image: redis:5.0
     volumes:
@@ -59,47 +28,14 @@ services:
     env_file: ./conf/rabbitmq/rabbitmq.env
     container_name: core_portal_rabbitmq
 
-  websockets:
-    image: ${PORTAL_IMAGE}:${PORTAL_TAG}
-    command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
-    volumes:
-      - ./conf/certificates/cep.dev.crt:/etc/ssl/certs/portal.cer
-      - ./conf/certificates/cep.dev.key/:/etc/ssl/private/portal.key
-      - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
-      - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
-    container_name: core_portal_websockets
-
-  django:
-    image: ${PORTAL_IMAGE}:${PORTAL_TAG}
-    volumes:
-      - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
-      - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
-      - /var/www/portal/portal/media:/srv/www/portal/server/media
-      - /var/www/portal/portal/static:/srv/www/portal/server/static
-     # uwsgi is not working in a development environment as containers
-     # are making non-secure (i.e. http) requests to other containers
-     # - ./conf/uwsgi/uwsgi_core.ini:/srv/www/portal/server/conf/uwsgi/uwsgi_core.ini
-    dns:
-      - 8.8.8.8
-      - 8.8.4.4
-    stdin_open: true
-    tty: true
-    # uwsgi is not working in a development environment as containers
-    # are making non-secure (i.e. http) requests to other containers
-    #command: uwsgi --ini /srv/www/portal/server/conf/uwsgi/uwsgi_core.ini
-    command: python manage.py runserver --noasgi 0.0.0.0:6000
-    container_name: core_portal_django
-
-  workers:
-    image: ${PORTAL_IMAGE}:${PORTAL_TAG}
-    volumes:
-      - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
-      - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
-    command: "celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=10"
-    container_name: core_portal_workers
+  memcached:
+    image: memcached:latest
+    command: ["-m", "1024m"]
+    container_name: core_portal_memcached
+    restart: always
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     ulimits:
       memlock: -1
     environment:
@@ -134,16 +70,88 @@ services:
       - POSTGRES_DB=taccsite
       - PGDATA=/var/lib/postgresql/data/portal
 
-  protx:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+  nginx:
+    image: nginx
     volumes:
-      - ./protx:/app/protx
+      - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./conf/nginx/protx.location.conf:/etc/nginx/conf.d/protx.location.conf
+      - ./conf/nginx/data.location.conf:/etc/nginx/conf.d/data.location.conf
+      - ./conf/nginx/assets.location.conf:/etc/nginx/conf.d/assets.location.conf
+      - ./conf/uwsgi/uwsgi_params:/etc/nginx/uwsgi_params
+      - ./conf/certificates/dhparam.pem:/etc/ssl/dhparam.pem
+      - ./conf/certificates/cep.dev.crt:/etc/ssl/certs/portal.cer
+      - ./conf/certificates/cep.dev.key/:/etc/ssl/private/portal.key
+      - /var/www/portal/cms/static:/var/www/portal/cms/static
+      - /var/www/portal/cms/media:/var/www/portal/cms/media
+      - /var/www/portal/portal/media:/var/www/portal/portal/media
+      - /var/www/portal/portal/static:/var/www/portal/portal/static
+      - protx_geospatial_data:/protx-data/static
+      - ./protx-client:/var/www/portal/protx-client
+      - protx_app_distribution:/protx-app-distribution
+    ports:
+      - 80:80
+      - 443:443
+    container_name: core_portal_nginx
+    depends_on:
+      - cms
+      - django
+
+  websockets:
+    image: ${PORTAL_IMAGE}:${PORTAL_TAG}
+    volumes:
+      - ./conf/certificates/cep.dev.crt:/etc/ssl/certs/portal.cer
+      - ./conf/certificates/cep.dev.key/:/etc/ssl/private/portal.key
+      - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
+      - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
+    container_name: core_portal_websockets
+    # ** NOTE: Run this daphne command below to run a production-ready daphne server,
+    # ** matching deployed configurations. Be aware there is no autoreload for local
+    # ** development with this enabled.
+    # command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
+    command: 'python manage.py runserver 0.0.0.0:9000'
+
+  django:
+    image: ${PORTAL_IMAGE}:${PORTAL_TAG}
+    volumes:
+      - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
+      - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
+      - /var/www/portal/portal/media:/srv/www/portal/server/media
+      - /var/www/portal/portal/static:/srv/www/portal/server/static
+     # uwsgi is not working in a development environment as containers
+     # are making non-secure (i.e. http) requests to other containers
+     # - ./conf/uwsgi/uwsgi_core.ini:/srv/www/portal/server/conf/uwsgi/uwsgi_core.ini
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    stdin_open: true
+    tty: true
+    # uwsgi is not working in a development environment as containers
+    # are making non-secure (i.e. http) requests to other containers
+    #command: uwsgi --ini /srv/www/portal/server/conf/uwsgi/uwsgi_core.ini
+    command: python manage.py runserver --noasgi 0.0.0.0:6000
+    container_name: core_portal_django
+
+  workers:
+    image: ${PORTAL_IMAGE}:${PORTAL_TAG}
+    volumes:
+      - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
+      - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
+      - /var/www/portal/portal/media:/srv/www/portal/server/media
+      - /var/www/portal/portal/static:/srv/www/portal/server/static
+    command: "celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=10"
+    container_name: core_portal_workers
+
+  protx:
+    image: ${PROTX_DASHBOARD_IMAGE}:${PROTX_DASHBOARD_TAG}
+    # build:
+    #   context: .
+    #   dockerfile: ./Dockerfile
+    volumes:
+      # - ./protx:/app/protx
       - ~/protx-data:/protx-data
-      - type: volume
-        source: protx_app_distribution
-        target: /app/protx-client/dist/
+      # - type: volume
+      #   source: protx_app_distribution
+      #   target: /app/protx-client/dist/
     ports:
       - 8000:8000
     dns:
@@ -151,7 +159,7 @@ services:
       - 8.8.4.4
     environment:
       - FLASK_APP=/app/protx/app.py
-      - FLASK_ENV=development
+      - FLASK_ENV=production  #development
       - USE_DEV_CLIENT=false #  if false, use the pre-built-container client.
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
     # ** matching deployed configurations. Be aware there is no autoreload for local
     # ** development with this enabled.
     # command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
-    command: 'python manage.py runserver 0.0.0.0:9000'
+    # command: 'python manage.py runserver 0.0.0.0:9000'
 
   django:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
@@ -136,8 +136,8 @@ services:
     volumes:
       - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
       - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
-      - /var/www/portal/portal/media:/srv/www/portal/server/media
-      - /var/www/portal/portal/static:/srv/www/portal/server/static
+      # - /var/www/portal/portal/media:/srv/www/portal/server/media
+      # - /var/www/portal/portal/static:/srv/www/portal/server/static
     command: "celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=10"
     container_name: core_portal_workers
 
@@ -150,7 +150,6 @@ services:
       dockerfile: ./Dockerfile
     volumes:
       - ~/protx-data:/protx-data
-      # Comment out these two volumes if using an image.
       - ./protx:/app/protx
       - type: volume
         source: protx_app_distribution
@@ -163,7 +162,7 @@ services:
     environment:
       - FLASK_APP=/app/protx/app.py
       - FLASK_ENV=development
-      - USE_DEV_CLIENT=false #  if false, use the pre-built-container client.
+      - USE_DEV_CLIENT=true  # if false, use the pre-built-container client.
     stdin_open: true
     tty: true
     container_name: protx
@@ -190,4 +189,4 @@ volumes:
   core_portal_postgres_data:
   core_cms_postgres_data:
   protx_geospatial_data:
-  protx_app_distribution: # Can be used for testing client built-in-container locally. Comment out if testing an image.
+  protx_app_distribution: # Used to test the pre-built-container client locally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
     # ** matching deployed configurations. Be aware there is no autoreload for local
     # ** development with this enabled.
     # command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
-    # command: 'python manage.py runserver 0.0.0.0:9000'
+    command: 'python manage.py runserver 0.0.0.0:9000'
 
   django:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
@@ -136,8 +136,6 @@ services:
     volumes:
       - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
       - ./conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
-      # - /var/www/portal/portal/media:/srv/www/portal/server/media
-      # - /var/www/portal/portal/static:/srv/www/portal/server/static
     command: "celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=10"
     container_name: core_portal_workers
 
@@ -189,4 +187,4 @@ volumes:
   core_portal_postgres_data:
   core_cms_postgres_data:
   protx_geospatial_data:
-  protx_app_distribution: # Used to test the pre-built-container client locally.
+  protx_app_distribution:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# The .env file sets ENVVARS for the Docker CLI used by this compose file.
+---
 version: "3"
 services:
   cms:
@@ -150,7 +152,7 @@ services:
     environment:
       - FLASK_APP=/app/protx/app.py
       - FLASK_ENV=development
-      - USE_DEV_CLIENT=true #  if false, use built-in-container client
+      - USE_DEV_CLIENT=false #  if false, use the pre-built-container client.
     stdin_open: true
     tty: true
     container_name: protx

--- a/docker_repo.var
+++ b/docker_repo.var
@@ -1,0 +1,1 @@
+protx-dashboard

--- a/docker_repo.var
+++ b/docker_repo.var
@@ -1,1 +1,0 @@
-protx-dashboard


### PR DESCRIPTION
## Overview: ##

Adds the Makefile to enable simplified local development and expose the calls for the Jenkins deployment workfows needed to build, publish and deploy the dashboard with the portal.

## Related Jira tickets: ##

* [COOKS-276](https://jira.tacc.utexas.edu/browse/COOKS-276)
* [COOKS-277](https://jira.tacc.utexas.edu/browse/COOKS-277)
* [COOKS-278](https://jira.tacc.utexas.edu/browse/COOKS-278)

## Summary of Changes: ##

- Added a Makefile.
- Established the Jenkins build & Publish job here: http://jenkins01.tacc.utexas.edu:8080/view/Protx/job/Protx_Dashboard_Image/
- Updated the Core Portal Deployments repo in conjunction.
- I forgot to PR this, so the changes are already in `main`: https://github.com/TACC/Core-Portal-Deployments/tree/main/protx/camino

## Testing Steps: ##
1. Build and run locally using the make commands (`make build`, `make build-full`, `make start`, `make stop`).
2. Login to Jenkins and publish an image from a branch to dockerhub: https://hub.docker.com/repository/docker/taccwma/protx-dashboard)
3. Bonus test: Swap out the values in your local `.env` and `docker-compose.yml` to run the image instead of building locally.
4. Deploy this thing to PPRD and see what explodes!!!!

## UI Photos:

## Notes: ##
