### PR TITLE
Rename container to align with camino

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,8 @@ services:
     container_name: core_portal_nginx
     depends_on:
       - cms
-      - django
+      - core
+      - protx
 
   websockets:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
@@ -110,7 +111,7 @@ services:
     # command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
     command: 'python manage.py runserver 0.0.0.0:9000'
 
-  django:
+  core:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
     volumes:
       - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -15,7 +15,7 @@ def is_setup_complete() -> bool:
     # making request directly to core django. alternatively, we could
     # make the request to the request.get_host() (but then a bit
     # tricky if it is local development and accessing cep.dev)
-    r = requests.get("http://django:6000/api/workbench/", cookies=request.cookies)
+    r = requests.get("http://core:6000/api/workbench/", cookies=request.cookies)
     r.raise_for_status()
     json_response = r.json()
     return json_response['response']['setupComplete']


### PR DESCRIPTION
## Overview: ##

Rename CORE container to align with camino.

This fixes bug on pprd where we are using the wrong service name to determine if user is logged-in/setupcomplete.

## Related Jira tickets: ##

None

## Testing Steps: ##
1. Test that things work as expected locally

