### PR TITLE
Task/COOKS-282: fix access from protx to core

### DIFF
--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -10,9 +10,11 @@ logger = logging.getLogger(__name__)
 
 cache = Cache("database_cache")
 
+
 def get_host():
     host = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
     return host
+
 
 def is_setup_complete() -> bool:
     host = get_host()


### PR DESCRIPTION
## Overview: ##

This PR does
* Updates how host for `api/workbench/` is derived.  We want to use service when doing local dev (as cep.dev wouldn't work) and then actual full host name when on prod/staging
* Also, update setupComplete logic as CEP Core responses has changed. Previously, /api/workbench required authed users and always had a setupComplete value.  Now guests can request it and then there is no setupComplete value.


## Related Jira tickets: ##

* [COOKS-282](https://jira.tacc.utexas.edu/browse/COOKS-282)

## Testing Steps: ##
1. Run normally
2. Ensure you can login and get access as usual

