### PR TITLE
Update decorators.py

### DIFF
--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -22,7 +22,7 @@ def is_setup_complete() -> bool:
         # unable to access cep.dev (as actual site on web) so using docker service instead.  Note that staging/prod are
         # unable to use the service directly (https-requirement for uwsgi configs?)
         host = "http://core:6000/"
-    r = requests.get(host + "api/workbench/", cookies=request.cookies)
+    r = requests.get(host + "/api/workbench/", cookies=request.cookies)
     r.raise_for_status()
     json_response = r.json()
     if 'setupComplete' in json_response['response']:


### PR DESCRIPTION
Missing a pre-pended slash before the route to the api.

## Overview: ##

## Related Jira tickets: ##

* [COOKS-123](https://jira.tacc.utexas.edu/browse/COOKS-123)

## Summary of Changes: ##

## Testing Steps: ##
1.

## UI Photos:

## Notes: ##
