### PR TITLE
Updated the Map colors 

### DIFF
--- a/protx-client/src/components/ProTx/components/maps/ProtxColors.css
+++ b/protx-client/src/components/ProTx/components/maps/ProtxColors.css
@@ -12,17 +12,7 @@
 
 /* areas */
 .display-layout-map {
-    /* Wes' Old Colors */
-    /*
-    --hue1: #EAF6C7;
-    --hue2: #D4EC8E;
-    --hue3: #A9C47F;
-    --hue4: #007A53;
-    --hue5: #003B5C;
-    --hue6: #001E2E;
-    */
-
-    /* Francesca's New Colors */
+    /* COOKS-251: Updated-Map-Colors-Francescas-Inputs  */
     --hue1: #eff5d6;
     --hue2: #c6e8b0;
     --hue3: #8fcca1;

--- a/protx-client/src/components/ProTx/components/maps/ProtxColors.css
+++ b/protx-client/src/components/ProTx/components/maps/ProtxColors.css
@@ -12,18 +12,23 @@
 
 /* areas */
 .display-layout-map {
+    /* Wes' Old Colors */
+    /*
     --hue1: #EAF6C7;
-    /* (new) between "Light lime" and white */
     --hue2: #D4EC8E;
-    /* "Light lime" */
     --hue3: #A9C47F;
-    /* "Light green" */
     --hue4: #007A53;
-    /* "Cook Children’s green" */
     --hue5: #003B5C;
-    /* "Cook Children’s blue" */
     --hue6: #001E2E;
-    /* (new) between "Cook Children’s green" and black */
+    */
+
+    /* Francesca's New Colors */
+    --hue1: #eff5d6;
+    --hue2: #c6e8b0;
+    --hue3: #8fcca1;
+    --hue4: #62ad9c;
+    --hue5: #3c7d8a;
+    --hue6: #26547a;
 }
 
 .leaflet-tile-pane > *:nth-child(2) path[fill="#ffffd4"] {


### PR DESCRIPTION
Uses the color palette identified by Francescas Samsel and the COOKS people and reported in a docx file.

## Overview: ##

## Related Jira tickets: ##

* [COOKS-251](https://jira.tacc.utexas.edu/browse/COOKS-251)

## Summary of Changes: ##

See map with *slightly* tweaked colors.

## Testing Steps: ##

1. Build and run as usual.
2. Look at the map.
3. See colors. =)

## UI Photos:

![Screen Shot 2022-07-13 at 6 26 48 PM](https://user-images.githubusercontent.com/3238078/178853751-0f8b4458-4b20-4452-97d8-4ebe91bf12a4.png)

## Notes: ##
