### PR TITLE
Task/COOKS-268: add support for census tracts in demographic view

### DIFF
--- a/.env
+++ b/.env
@@ -16,4 +16,4 @@ PORTAL_TAG=be3fea2
 # When testing published images, these would be used but see docker-compose.yml as it is configured to build its own image and use a volume of local source code would would need to be disabled
 PROTX_DASHBOARD_IMAGE=taccwma/protx-dashboard
 PROTX_DASHBOARD_TAG=7800601
-PROTX_GEOSPATIAL_TAG=334920b
+PROTX_GEOSPATIAL_TAG=4cddb3a

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Followed by:
     docker exec core_portal_cms python3 manage.py migrate
     docker exec core_portal_cms python3 manage.py collectstatic --noinput
 ```
+
+To run queries ahead-of-time (needed whenever databases have changed) so that they are cached and do
+not exceed the timeout:
+```
+docker exec -it protx python3 scripts/run_queries.py
+```
+
 Note: CEP portal is not completely configured and is missing steps for ES etc
 
 ### Configure pages/iframe

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,8 @@ services:
     container_name: core_portal_nginx
     depends_on:
       - cms
-      - django
+      - core
+      - protx
 
   websockets:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
@@ -110,7 +111,7 @@ services:
     # command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
     command: 'python manage.py runserver 0.0.0.0:9000'
 
-  django:
+  core:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
     volumes:
       - ./conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,7 @@ services:
 
   protx_geospatial:
     image: taccwma/protx-geospatial:${PROTX_GEOSPATIAL_TAG}
+    pull_policy: always
     volumes:
       - type: volume
         source: protx_geospatial_data

--- a/protx-client/src/components/ProTx/components/dashboard/DashboardDisplay.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DashboardDisplay.jsx
@@ -176,6 +176,7 @@ function DashboardDisplay() {
                   setMaltreatmentTypes={setMaltreatmentTypes}
                   setObservedFeature={setObservedFeature}
                   setUnit={setUnit}
+                  setGeography={setGeography}
                   downloadResources={handleDownloadResources}
                 />
                 <div className="display-layout-root">

--- a/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
@@ -132,8 +132,6 @@ function DisplaySelectors({
             </option>
             <option
               value="tract"
-              disabled
-              /* # Support county and tract for https://jira.tacc.utexas.edu/browse/COOKS-135 */
             >
               Census Tracts
             </option>

--- a/protx-client/src/components/ProTx/components/data/meta.js
+++ b/protx-client/src/components/ProTx/components/data/meta.js
@@ -24,7 +24,7 @@ export const OBSERVED_FEATURES_TOP_FIELDS = [
 // TOOO: we should correct vector files to all be the same thing (GEOID)
 export const GEOID_KEY = {
   cbsa: 'GEOID_left',
-  census_tract: 'GEOID',
+  tract: 'GEOID',
   county: 'GEO_ID',
   dfps_region: 'Sheet1__Re',
   urban_area: 'GEOID10',

--- a/protx-client/src/components/ProTx/components/maps/MainMap.jsx
+++ b/protx-client/src/components/ProTx/components/maps/MainMap.jsx
@@ -407,6 +407,8 @@ function MainMap({
             // Simple zoom to point clicked and having fixed zoom level for counties
             // See https://jira.tacc.utexas.edu/browse/COOKS-54
             map.setView(e.latlng, 9);
+          } else {
+            map.setView(e.latlng, 11);
           }
         } else {
           updateSelectedGeographicFeature('');

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -15,7 +15,7 @@ def is_setup_complete() -> bool:
     # making request directly to core django. alternatively, we could
     # make the request to the request.get_host() (but then a bit
     # tricky if it is local development and accessing cep.dev)
-    r = requests.get("http://django:6000/api/workbench/", cookies=request.cookies)
+    r = requests.get("http://core:6000/api/workbench/", cookies=request.cookies)
     r.raise_for_status()
     json_response = r.json()
     return json_response['response']['setupComplete']

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -5,6 +5,8 @@ import os
 import logging
 from flask import request, redirect
 import requests
+from urllib.parse import urljoin
+
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +24,7 @@ def is_setup_complete() -> bool:
         # unable to access cep.dev (as actual site on web) so using docker service instead.  Note that staging/prod are
         # unable to use the service directly (https-requirement for uwsgi configs?)
         host = "http://core:6000/"
-    r = requests.get(host + "/api/workbench/", cookies=request.cookies)
+    r = requests.get(urljoin(host, "/api/workbench"), cookies=request.cookies)
     r.raise_for_status()
     json_response = r.json()
     if 'setupComplete' in json_response['response']:

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -11,14 +11,31 @@ logger = logging.getLogger(__name__)
 cache = Cache("database_cache")
 
 
+def get_host():
+    host = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
+    return host
+
+
 def is_setup_complete() -> bool:
-    # making request directly to core django. alternatively, we could
-    # make the request to the request.get_host() (but then a bit
-    # tricky if it is local development and accessing cep.dev)
-    r = requests.get("http://core:6000/api/workbench/", cookies=request.cookies)
+    host = get_host()
+    if host.endswith("cep.dev"):
+        # unable to access cep.dev (as actual site on web) so using docker service instead.  Note that staging/prod are
+        # unable to use the service directly (https-requirement for uwsgi configs?)
+        host = "http://core:6000/"
+    r = requests.get(host + "api/workbench/", cookies=request.cookies)
     r.raise_for_status()
     json_response = r.json()
-    return json_response['response']['setupComplete']
+    if 'setupComplete' in json_response['response']:
+        return json_response['response']['setupComplete']
+    else:
+        # User isn't logged in which is unexpected as pages (which contain this SPA as an iframe)
+        # are controlled by CMS which should require a login
+        #
+        # If if the future, CMS are no longer configured to keep pages behind login, then we should refactor
+        # this function and `onboarded_user_setup_complete` to redirect to login instead of /workbench/onboarding if
+        # user isn't logged in.  See https://jira.tacc.utexas.edu/browse/COOKS-279
+        logger.error("User not logged in which is unexpected as CMS should be blocking pages")
+        return False
 
 
 def onboarded_user_setup_complete(function):
@@ -28,10 +45,8 @@ def onboarded_user_setup_complete(function):
     def wrapper(*args, **kwargs):
         try:
             if not is_setup_complete():
-                redirect_url = request.url_root.split(',')[0] if ',' in request.url_root else request.url_root
-                return redirect(redirect_url + '/workbench/onboarding')
+                return redirect(get_host() + '/workbench/onboarding')
         except Exception as e:
-            # User isn't logged in which is unexpected as pages (which contain this SPA as an iframe) are controlled by CMS which should require a login
             logger.error(e)
             raise Forbidden
         else:

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -22,7 +22,7 @@ def is_setup_complete() -> bool:
         # unable to access cep.dev (as actual site on web) so using docker service instead.  Note that staging/prod are
         # unable to use the service directly (https-requirement for uwsgi configs?)
         host = "http://core:6000/"
-    r = requests.get(host + "api/workbench/", cookies=request.cookies)
+    r = requests.get(host + "/api/workbench/", cookies=request.cookies)
     r.raise_for_status()
     json_response = r.json()
     if 'setupComplete' in json_response['response']:

--- a/protx/decorators.py
+++ b/protx/decorators.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 
 logger = logging.getLogger(__name__)
 
-cache = Cache("database_cache")
+cache = Cache("database_cache", disk_min_file_size=0, eviction_policy="none")
 
 
 def get_host():
@@ -82,13 +82,10 @@ def check_db_timestamp_and_cache_validity(db_file):
         def wrapper(*args, **kwargs):
             current_data_db_timestamp = os.path.getmtime(db_file)
             cached_data_db_timestamp = cache.get(db_file)
-            logger.debug("Getting cache results for {}: current file's modified time {}"
-                         " vs cached modified time {}.".format(db_file,
-                                                               current_data_db_timestamp,
-                                                               cached_data_db_timestamp))
             if cached_data_db_timestamp != current_data_db_timestamp:
-                logger.info("Removing cache related to file '{}' as it has been updated.".format(db_file))
-                cache.clear()
+                logger.info(f"Removing any cache related to file '{db_file}' as the derived file's "
+                            f"modified time {db_file} != cached modified time {cached_data_db_timestamp}.")
+                cache.evict(db_file)
                 cache.set(db_file, current_data_db_timestamp)
             return f(*args, **kwargs)
         return wrapper
@@ -110,7 +107,7 @@ def memoize_db_results(db_file):
 
     def decorator(f):
         @check_db_timestamp_and_cache_validity(db_file)
-        @cache.memoize()
+        @cache.memoize(tag=db_file)
         @wraps(f)
         def wrapper(*args, **kwargs):
             return f(*args, **kwargs)

--- a/protx/scripts/run_queries.py
+++ b/protx/scripts/run_queries.py
@@ -1,0 +1,14 @@
+from protx.api import get_maltreatment_cached, get_demographics_cached, get_resources_cached
+import time
+
+def call_function_and_report(f):
+    start = time.time()
+    print(f"{f.__name__} is running")
+    f()
+    total_time = time.time() - start
+    print(f"  {f.__name__} completed in {total_time} seconds")
+
+functions_to_cache = [get_maltreatment_cached, get_demographics_cached, get_resources_cached]
+
+for func in functions_to_cache:
+    call_function_and_report(func)

--- a/protx/scripts/run_queries.py
+++ b/protx/scripts/run_queries.py
@@ -1,12 +1,14 @@
 from protx.api import get_maltreatment_cached, get_demographics_cached, get_resources_cached
 import time
 
+
 def call_function_and_report(f):
     start = time.time()
     print(f"{f.__name__} ...")
     f()
     total_time = time.time() - start
     print(f"  {f.__name__} completed in {total_time} seconds")
+
 
 functions_to_cache = [get_maltreatment_cached, get_demographics_cached, get_resources_cached]
 

--- a/protx/scripts/run_queries.py
+++ b/protx/scripts/run_queries.py
@@ -3,12 +3,16 @@ import time
 
 def call_function_and_report(f):
     start = time.time()
-    print(f"{f.__name__} is running")
+    print(f"{f.__name__} ...")
     f()
     total_time = time.time() - start
     print(f"  {f.__name__} completed in {total_time} seconds")
 
 functions_to_cache = [get_maltreatment_cached, get_demographics_cached, get_resources_cached]
 
+print(f" Running {len(functions_to_cache)} methods in order to cache their results")
+
 for func in functions_to_cache:
     call_function_and_report(func)
+
+print("Completed.")

--- a/protx/utils/db.py
+++ b/protx/utils/db.py
@@ -28,8 +28,7 @@ GROUP BY
     m.MALTREATMENT_NAME;
 '''
 
-# Support county and tract for https://jira.tacc.utexas.edu/browse/COOKS-135
-DEMOGRAPHICS_QUERY = "SELECT * FROM demographics d WHERE d.GEOTYPE='county'"
+DEMOGRAPHICS_QUERY = "SELECT * FROM demographics d WHERE d.GEOTYPE='county' OR d.GEOTYPE='tract'"
 
 DEMOGRAPHICS_MIN_MAX_QUERY = '''
 SELECT
@@ -40,7 +39,7 @@ SELECT
     MIN(d.value) AS MIN,
     MAX(d.value) AS MAX
 FROM demographics d
-WHERE d.GEOTYPE='county'
+WHERE d.GEOTYPE='county' OR d.GEOTYPE='tract'
 GROUP BY
     d.GEOTYPE,
     d.UNITS,
@@ -85,7 +84,7 @@ def create_dict(data, level_keys):
         if "MAX" in row:
             value_key = row["UNITS"]
             if row["MIN"] is None or row["MAX"] is None:
-                logger.error("max/min problem with this row: {}".format(row))
+                logger.debug("max/min problem with this row: {}".format(row))
                 continue
             value = {key.lower(): int(row[key]) if value_key == "count" else row[key] for key in ["MAX", "MIN"]}
         elif "VALUE" in row:


### PR DESCRIPTION
## Overview: ##

Add support for census tracts in the demographic view

## Related Jira tickets: ##

* [COOKS-263](https://jira.tacc.utexas.edu/browse/COOKS-263)
* [COOKS-268](https://jira.tacc.utexas.edu/browse/COOKS-268)

## Summary of Changes: ##

## Testing Steps: ##
1. Bring up portal with docker compose as usual
2. Run `docker exec -it protx python3 scripts/run_queries.py`
3.  See that you can use census tracts in demographics view
 
## UI Photos:

## Notes: ##

- [ ] ~Add testing steps~
- [ ] ~Optimize demographic queries to remove unneeded data.~
- [x] add ticket for proper zooming (https://jira.tacc.utexas.edu/browse/COOKS-290)
- [ ] ~Clarify if years can be changed in demographics (regression?)~ (in dev meeting)
- [ ] ~Add ticket for logs missing for protx container (?)~  (they are there)