### PR TITLE
task/COOKS-289 add street address to resources csv

### DIFF
--- a/protx/tests/api_test.py
+++ b/protx/tests/api_test.py
@@ -124,7 +124,7 @@ def test_get_resources_download(test_client, core_api_workbench_request):
     assert resp.status_code == 200
     assert resp.headers['Content-Disposition'].startswith("attachment; filename=\"Erath_county_resources")
     assert resp.headers['Content-Disposition'].endswith('.csv\"')
-    assert resp.get_data(as_text=True).startswith("NAME,CITY,STATE,POSTAL_CODE,PHONE,WEBSITE,LATITUDE,LONGITUDE,NAICS_CODE,NAICS_DESCRIPTION")
+    assert resp.get_data(as_text=True).startswith("NAME,STREET,CITY,STATE,POSTAL_CODE,PHONE,WEBSITE,HOVER_DESCRIPTION,LATITUDE,LONGITUDE,NAICS_CODE,NAICS_DESCRIPTION")
 
 
 def test_get_resources_download_unauthed(test_client, core_api_workbench_request_unauthed):

--- a/protx/tests/api_test.py
+++ b/protx/tests/api_test.py
@@ -124,7 +124,7 @@ def test_get_resources_download(test_client, core_api_workbench_request):
     assert resp.status_code == 200
     assert resp.headers['Content-Disposition'].startswith("attachment; filename=\"Erath_county_resources")
     assert resp.headers['Content-Disposition'].endswith('.csv\"')
-    assert resp.get_data(as_text=True).startswith("NAME,STREET,CITY,STATE,POSTAL_CODE,PHONE,WEBSITE,HOVER_DESCRIPTION,LATITUDE,LONGITUDE,NAICS_CODE,NAICS_DESCRIPTION")
+    assert resp.get_data(as_text=True).startswith("NAME,STREET,CITY,STATE,POSTAL_CODE,PHONE,WEBSITE,LATITUDE,LONGITUDE,NAICS_CODE,NAICS_DESCRIPTION")
 
 
 def test_get_resources_download_unauthed(test_client, core_api_workbench_request_unauthed):

--- a/protx/utils/resources.py
+++ b/protx/utils/resources.py
@@ -43,7 +43,7 @@ class Echo:
 
 def download_resources(naics_codes, area, geoid):
     """Get resources csv"""
-    download_fields = ["NAME", "STREET". "CITY", "STATE", "POSTAL_CODE", "PHONE", "WEBSITE", "HOVER_DESCRIPTION", "LATITUDE", "LONGITUDE", "NAICS_CODE"]
+    download_fields = ["NAME", "STREET", "CITY", "STATE", "POSTAL_CODE", "PHONE", "WEBSITE", "LATITUDE", "LONGITUDE", "NAICS_CODE"]
 
     if area != "county":
         # currently assuming county and query is hardcoded for "texas_counties"

--- a/protx/utils/resources.py
+++ b/protx/utils/resources.py
@@ -43,7 +43,7 @@ class Echo:
 
 def download_resources(naics_codes, area, geoid):
     """Get resources csv"""
-    download_fields = ["NAME", "CITY", "STATE", "POSTAL_CODE", "PHONE", "WEBSITE", "LATITUDE", "LONGITUDE", "NAICS_CODE"]
+    download_fields = ["NAME", "STREET". "CITY", "STATE", "POSTAL_CODE", "PHONE", "WEBSITE", "HOVER_DESCRIPTION", "LATITUDE", "LONGITUDE", "NAICS_CODE"]
 
     if area != "county":
         # currently assuming county and query is hardcoded for "texas_counties"


### PR DESCRIPTION
## Overview: ##

Add missing street address to downloaded resources csv file

## Related Jira tickets: ##

* [COOKS-289](https://jira.tacc.utexas.edu/browse/COOKS-289)

## Summary of Changes: ##

## Testing Steps: ##
1. Download a county and confirm that there are street addresses

## UI Photos:

## Notes: ##
