### PR TITLE
task/COOKS-285: turn off keyboard to avoid focus issue

### DIFF
--- a/protx-client/src/components/ProTx/components/maps/MainMap.jsx
+++ b/protx-client/src/components/ProTx/components/maps/MainMap.jsx
@@ -128,6 +128,7 @@ function MainMap({
     const texasBounds = texasOutlineGeojson.getBounds(texasOutlineGeojson);
 
     const newMap = L.map(mapContainer, {
+      keyboard: false,
       zoom: zoomLevel,
       minZoom: 6,
       maxZoom: 16,


### PR DESCRIPTION
## Overview: ##

Turn off leaflet's keyboard to avoid focus issue seen on Prod/Preprod.  this PR fixes the issue but should probably be fixed via making the sizing better with portal/iframe.

## Related Jira tickets: ##

* [COOKS-285](https://jira.tacc.utexas.edu/browse/COOKS-285)

## Testing Steps: ##

### Recreate issue
1. Checkout main
2. Access an iframe-version of app (i.e. /demographics and not /protx/dash/demographics)
3. Click on a county and notice that scrolling occurs for map
4. Click on a county and notice it is now selected

### Recreate issue
1. Checkout this branch.
2. Access an iframe-version of app (i.e. /demographics and not /protx/dash/demographics)
4. Click on a county and notice it is now selected on **the first click**

## Notes: ##
- [ ] open up follow on ticket to be discussed with @taoteg @duckonomy 
