### PR TITLE
task/COOKS-304: Removed non-supported areas from dropdown

### DIFF
--- a/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
@@ -137,17 +137,6 @@ function DisplaySelectors({
             </option>
             <option value="county">Counties</option>
           </optgroup>
-          <optgroup label="Not currently available">
-            <option value="cbsa" disabled>
-              Core base statistical areas
-            </option>
-            <option value="urban_area" disabled>
-              Urban Areas
-            </option>
-            <option value="zcta" disabled>
-              Zip Codes
-            </option>
-          </optgroup>
         </DropdownSelector>
       </div>
       {setUnit && (


### PR DESCRIPTION
## Overview: ##

Remove non-supported areas from drop down

## Related Jira tickets: ##

* [COOKS-304](https://jira.tacc.utexas.edu/browse/COOKS-304)

## Summary of Changes: ##

## Testing Steps: ##
1. Run and check area dropdown in demographics view

## UI Photos:
![Screen Shot 2022-09-07 at 3 17 18 PM](https://user-images.githubusercontent.com/8287580/188969539-bf994ac0-6782-4371-9ce5-57c4acab2db2.png)

