### PR TITLE
task/COOKS-307: Improve zooming when switching between geographic areas

### DIFF
--- a/protx-client/src/components/ProTx/components/maps/MainMap.jsx
+++ b/protx-client/src/components/ProTx/components/maps/MainMap.jsx
@@ -341,6 +341,16 @@ function MainMap({
   }, [layersControl, map, resources]);
 
   useEffect(() => {
+    if (map && selectedGeographicFeature === '') {
+      // if selected geographic feature gets unset, we should zoom out
+      const texasOutlineGeojson = L.geoJSON(data.texasBoundary);
+      const texasBounds = texasOutlineGeojson.getBounds(texasOutlineGeojson);
+      map.fitBounds(texasBounds);
+    }
+  }, [map, data, selectedGeographicFeature]);
+
+
+  useEffect(() => {
     const vectorTile = `${dataServer}/data-static/vector/${geography}/2019/{z}/{x}/{y}.pbf`;
 
     if (map && layersControl) {


### PR DESCRIPTION

## Overview: ##

Improve zooming when switching between geographic areas:  Detect that selected geographic area is deselected and then zoom out to see all of Texas.

## Related Jira tickets: ##

* [COOKS-307](https://jira.tacc.utexas.edu/browse/COOKS-307)


## Testing Steps: ##
1. Select county
2. Switch to census tracts or dfps regions
3. See that you are zoomed out to all of Texas.
