### PR TITLE
Task/cooks 306 update plot header with additional geography type support

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/AnalyticsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  getFipsIdName,
+  getSelectedGeographyName,
   capitalizeString,
   getObservedFeaturesLabel
 } from '../shared/dataUtils';
@@ -14,8 +14,8 @@ function AnalyticsDetails({
   data
 }) {
   const observedFeaturesLabel = getObservedFeaturesLabel(observedFeature, data);
-  const selectedGeographicFeatureName = getFipsIdName(
-    selectedGeographicFeature
+  const selectedGeographicFeatureName = getSelectedGeographyName(
+    geography, selectedGeographicFeature
   );
   const geographyType = capitalizeString(geography);
 

--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -14,10 +14,13 @@ function DemographicsDetails({
   data
 }) {
   const observedFeaturesLabel = getObservedFeaturesLabel(observedFeature, data);
+  // TODO: Replace this FIPS specific method with a universal method to populate label for all geography types.
+  // TODO: Replicate use across other Chart *Details component views (or refactor *Details into a single component).
   const selectedGeographicFeatureName = getFipsIdName(
     selectedGeographicFeature
   );
   const geographyType = capitalizeString(geography);
+  console.log(geographyType, observedFeaturesLabel, selectedGeographicFeatureName);
 
   return (
     <>

--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  getFipsIdName,
+  getSelectedGeographyName,
   capitalizeString,
   getObservedFeaturesLabel
 } from '../shared/dataUtils';
@@ -13,17 +13,51 @@ function DemographicsDetails({
   selectedGeographicFeature,
   data
 }) {
-  const observedFeaturesLabel = getObservedFeaturesLabel(observedFeature, data);
-  const selectedGeographicFeatureName = getFipsIdName(
-    selectedGeographicFeature
-  );
-  const geographyType = capitalizeString(geography);
-
   // TODO: Replace the getFipsIdName() FIPS specific method with a universal method to populate label for all geography types.
   // TODO: Handle types: County, Tract, Dfps_region
   // TODO: Place this logic in the dataUtils.js file, replacing use of getFipsIdName().
   // TODO: Replicate use across other Chart *Details component views (or refactor *Details into a single component).
-  console.log(geographyType, observedFeaturesLabel, selectedGeographicFeatureName);
+
+  // Code logic.
+  // - identify the geographyType (County, Tract, Dfps_region)
+  // - get label txt for selected geographic region (using dataUtils)
+  // - assign values to selectedGeographicFeature (based on geographyType) for both label and value spans.
+
+  console.log(geography, observedFeature, selectedGeographicFeature); //, geographyType, observedFeaturesLabel, selectedGeographicFeatureName);
+
+  const observedFeaturesLabel = getObservedFeaturesLabel(observedFeature, data);
+  let selectedGeographicFeatureName = getSelectedGeographyName(
+    geography, selectedGeographicFeature
+  );
+  let geographyType;
+  let selectedGeographyTypeDisplayLabel;
+
+  switch (geography) {
+    case 'county':
+      selectedGeographyTypeDisplayLabel = 'FIPS';
+      // selectedGeographicFeature = '';
+      // selectedGeographicFeatureName = '';
+      geographyType = capitalizeString(geography);
+      break;
+    case 'tract':
+      selectedGeographyTypeDisplayLabel = 'Tract';
+      // selectedGeographicFeature = '';
+      selectedGeographicFeatureName = '';
+      geographyType = '';
+      break;
+    case 'dfps_region':
+      selectedGeographyTypeDisplayLabel = 'DFPS Region';
+      selectedGeographicFeature = '';
+      // selectedGeographicFeatureName = '';
+      // geographyType = capitalizeString(geography);
+      geographyType = '';
+      break;
+    default:
+      selectedGeographyTypeDisplayLabel = '';
+      selectedGeographicFeature = '';
+      selectedGeographicFeatureName = '';
+      geographyType = '';
+  };
 
   return (
     <>
@@ -31,7 +65,7 @@ function DemographicsDetails({
         <div className="plot-details-section">
           <div className="plot-details-section-selected">
             <span className="plot-details-section-selected-label">
-              FIPS: {selectedGeographicFeature}
+              {selectedGeographyTypeDisplayLabel} {selectedGeographicFeature}
             </span>
             <span className="plot-details-section-selected-value">
               {selectedGeographicFeatureName} {geographyType}

--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -14,12 +14,15 @@ function DemographicsDetails({
   data
 }) {
   const observedFeaturesLabel = getObservedFeaturesLabel(observedFeature, data);
-  // TODO: Replace this FIPS specific method with a universal method to populate label for all geography types.
-  // TODO: Replicate use across other Chart *Details component views (or refactor *Details into a single component).
   const selectedGeographicFeatureName = getFipsIdName(
     selectedGeographicFeature
   );
   const geographyType = capitalizeString(geography);
+
+  // TODO: Replace this FIPS specific method with a universal method to populate label for all geography types.
+  // TODO: Handle types: County, Tract, Dfps_region
+  // TODO: Place this logic in the dataUtils.js file, replacing use of getFipsIdName().
+  // TODO: Replicate use across other Chart *Details component views (or refactor *Details into a single component).
   console.log(geographyType, observedFeaturesLabel, selectedGeographicFeatureName);
 
   return (

--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -13,18 +13,6 @@ function DemographicsDetails({
   selectedGeographicFeature,
   data
 }) {
-  // TODO: Replace the getFipsIdName() FIPS specific method with a universal method to populate label for all geography types.
-  // TODO: Handle types: County, Tract, Dfps_region
-  // TODO: Place this logic in the dataUtils.js file, replacing use of getFipsIdName().
-  // TODO: Replicate use across other Chart *Details component views (or refactor *Details into a single component).
-
-  // Code logic.
-  // - identify the geographyType (County, Tract, Dfps_region)
-  // - get label txt for selected geographic region (using dataUtils)
-  // - assign values to selectedGeographicFeature (based on geographyType) for both label and value spans.
-
-  console.log(geography, observedFeature, selectedGeographicFeature); //, geographyType, observedFeaturesLabel, selectedGeographicFeatureName);
-
   const observedFeaturesLabel = getObservedFeaturesLabel(observedFeature, data);
   let selectedGeographicFeatureName = getSelectedGeographyName(
     geography, selectedGeographicFeature
@@ -35,21 +23,16 @@ function DemographicsDetails({
   switch (geography) {
     case 'county':
       selectedGeographyTypeDisplayLabel = 'FIPS';
-      // selectedGeographicFeature = '';
-      // selectedGeographicFeatureName = '';
       geographyType = capitalizeString(geography);
       break;
     case 'tract':
       selectedGeographyTypeDisplayLabel = 'Tract';
-      // selectedGeographicFeature = '';
       selectedGeographicFeatureName = '';
       geographyType = '';
       break;
     case 'dfps_region':
       selectedGeographyTypeDisplayLabel = 'DFPS Region';
       selectedGeographicFeature = '';
-      // selectedGeographicFeatureName = '';
-      // geographyType = capitalizeString(geography);
       geographyType = '';
       break;
     default:

--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -19,7 +19,7 @@ function DemographicsDetails({
   );
   const geographyType = capitalizeString(geography);
 
-  // TODO: Replace this FIPS specific method with a universal method to populate label for all geography types.
+  // TODO: Replace the getFipsIdName() FIPS specific method with a universal method to populate label for all geography types.
   // TODO: Handle types: County, Tract, Dfps_region
   // TODO: Place this logic in the dataUtils.js file, replacing use of getFipsIdName().
   // TODO: Replicate use across other Chart *Details component views (or refactor *Details into a single component).

--- a/protx-client/src/components/ProTx/components/charts/MainChart.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.jsx
@@ -8,7 +8,7 @@ import PredictiveFeaturesTable from './PredictiveFeaturesTable';
 import DemographicsDetails from './DemographicsDetails';
 import MaltreatmentDetails from './MaltreatmentDetails';
 import MainPlot from './MainPlot';
-import { getFipsIdName, capitalizeString } from '../shared/dataUtils';
+import { getSelectedGeographyName, capitalizeString } from '../shared/dataUtils';
 import './MainChart.css';
 
 function MainChart({
@@ -129,8 +129,8 @@ function MainChart({
      * We should review the plotly server-side code and identify a way to use the geoid value rather than pass the munged string value for selectedArea.
      * NOTE: We should identify a phased process for integrating a new plot from jupyter into the portal api so it is less intensive per sprint, makes more manageable PRs and helps WMA manage development  expectations better.
      **/
-    const selectedGeographicFeatureName = getFipsIdName(
-      selectedGeographicFeature
+    const selectedGeographicFeatureName = getSelectedGeographyName(
+      geography, selectedGeographicFeature
     );
 
     const selectedGeographicFeatureNameComplete = `${selectedGeographicFeatureName} ${capitalizeString(

--- a/protx-client/src/components/ProTx/components/charts/MaltreatmentDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MaltreatmentDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  getFipsIdName,
+  getSelectedGeographyName,
   capitalizeString,
   getMaltreatmentTypeNames
 } from '../shared/dataUtils';
@@ -13,8 +13,7 @@ function MaltreatmentDetails({
   maltreatmentTypes,
   data
 }) {
-  const fipsIdValue = getFipsIdName(selectedGeographicFeature);
-
+  const fipsIdValue = getSelectedGeographyName(geography, selectedGeographicFeature);
   const geographyLabel = capitalizeString(geography);
   const maltreatmentTypesList = getMaltreatmentTypeNames(
     maltreatmentTypes,

--- a/protx-client/src/components/ProTx/components/shared/dataUtils.js
+++ b/protx-client/src/components/ProTx/components/shared/dataUtils.js
@@ -29,26 +29,46 @@ const compareSimplifiedValueType = (observedFeature, valueType) => {
 /**
  * Get the county name for a given Geoid.
  * @param {String} currentGeoid
- * @returns {fipsIdName: string}
+ * @returns {geographyDisplayName: string}
  */
-const getFipsIdName = currentGeoid => {
-  const trimmedGeoid = currentGeoid.substring(currentGeoid.length - 3);
-  const countyObjects = PHR_MSA_COUNTIES[0];
+const getSelectedGeographyName = (geography, currentGeoid) => {
+  // console.log(currentGeoid);
+
+  let geographyName;
   let fipsIdName;
 
-  Object.keys(countyObjects).forEach(cty => {
-    const currentCounty = countyObjects[cty];
-    const baseCode = '000';
-    const countyCode = baseCode + currentCounty['FIPS Number']; // String.
-    const currentCountyCode = countyCode.slice(-3);
-    const currentCountyName = currentCounty['County Name'];
+  switch (geography) {
+    case 'county':
+      const trimmedGeoid = currentGeoid.substring(currentGeoid.length - 3);
+      const countyObjects = PHR_MSA_COUNTIES[0];
 
-    if (currentCountyCode === trimmedGeoid) {
-      fipsIdName = currentCountyName;
-    }
-  });
+      Object.keys(countyObjects).forEach(cty => {
+        const currentCounty = countyObjects[cty];
+        const baseCode = '000';
+        const countyCode = baseCode + currentCounty['FIPS Number']; // String.
+        const currentCountyCode = countyCode.slice(-3);
+        const currentCountyName = currentCounty['County Name'];
 
-  return fipsIdName;
+        if (currentCountyCode === trimmedGeoid) {
+          fipsIdName = currentCountyName;
+        }
+      });
+      geographyName = fipsIdName;
+      break;
+    case 'tract':
+      geographyName = 'tract_placeholder';
+      break;
+    case 'dfps_region':
+      // const regionLabel = currentGeoid.slice(2);
+      const regionLabel = currentGeoid.substring(currentGeoid.indexOf('-') + 1);
+      // geographyName = 'dfps_region__placeholder';
+      geographyName = regionLabel;
+      break;
+    default:
+      geographyName = '';
+  };
+
+  return geographyName;
 };
 
 /**
@@ -311,7 +331,7 @@ export {
   getMetaData,
   getObservedFeatureValue,
   getMaltreatmentAggregatedValue,
-  getFipsIdName,
+  getSelectedGeographyName,
   getMaltreatmentTypeNames,
   getMaltreatmentLabel,
   getObservedFeaturesLabel,


### PR DESCRIPTION
## Overview: ##

TODO:

- Replace the `getFipsIdName()` FIPS specific method with a universal method to populate label for all geography types.
- Replicate: Handle types: County, Tract, Dfps_region
- Place this logic in the dataUtils.js file, replacing use of getFipsIdName().
- Replicate use across other Chart *Details component views (or refactor *Details into a single component).

## Related Jira tickets: ##

* [COOKS-306](https://jira.tacc.utexas.edu/browse/COOKS-306)

## Summary of Changes: ##

## Testing Steps: ##
1. Run project and check that demographics plot heading info reflects correct geography type naming.

## UI Photos:

## Notes: ##
