### PR TITLE
Task/COOKS-316: Remove FIPS count from chart header

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -22,7 +22,8 @@ function DemographicsDetails({
 
   switch (geography) {
     case 'county':
-      selectedGeographyTypeDisplayLabel = 'FIPS';
+      selectedGeographyTypeDisplayLabel = '';
+      selectedGeographicFeature = ''
       geographyType = capitalizeString(geography);
       break;
     case 'tract':

--- a/protx-client/src/components/ProTx/components/charts/MaltreatmentDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MaltreatmentDetails.jsx
@@ -25,9 +25,6 @@ function MaltreatmentDetails({
       <div className="plot-details">
         <div className="plot-details-section">
           <div className="plot-details-section-selected">
-            <span className="plot-details-section-selected-label">
-              FIPS: {selectedGeographicFeature}
-            </span>
             <span className="plot-details-section-selected-value">
               {fipsIdValue} {geographyLabel}
             </span>


### PR DESCRIPTION
## Overview: ##
Remove FIPS count from chart headers for the Demographics and Child Maltreament views.

## Related Jira tickets: ##

* [COOKS-316](https://jira.tacc.utexas.edu/browse/COOKS-316)

## Summary of Changes: ##
Remove FIPS count for chart headers for the demographics (with Counties selected in Area pulldown menu) and maltreament views.

## Testing Steps: ##
1. Go to https://cep.test/protx/dash/demographics
2. Select Counties from the Area pulldown menu
3. Check the chart header on the right side and ensure that the FIPS count is removed.
4. Go to https://cep.test/protx/dash/maltreatment
5. Check the chart header on the right side and ensure that the FIPS count is removed.

## UI Photos:
Pre change:
![demographics_pre_change](https://user-images.githubusercontent.com/79928051/193357511-9fdcdb5b-4d7a-4c05-8a86-6b7a33ca3bb0.png)
![maltreatment_pre_change](https://user-images.githubusercontent.com/79928051/193357575-5bbc7653-2478-465a-8062-9eb04d0af5ac.png)

Post change:
![demographics_post_change](https://user-images.githubusercontent.com/79928051/193357605-7098636a-d94a-4356-9c96-597dcd3fd100.png)
![maltreatment_post_change](https://user-images.githubusercontent.com/79928051/193357636-09878b60-3913-4a6a-9385-4dfcc2fe6193.png)
