### PR TITLE
	 Added DFPS region number to the plot-details-section-selected-label…

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -32,7 +32,7 @@ function DemographicsDetails({
       break;
     case 'dfps_region':
       selectedGeographyTypeDisplayLabel = 'DFPS Region';
-      selectedGeographicFeature = '';
+      selectedGeographicFeature = selectedGeographicFeature.split('-', 1);
       geographyType = '';
       break;
     default:


### PR DESCRIPTION
… in the DFPS Region area display when a county is selected.

## Overview: ##
To display DFPS region numbers when using the DFPS region area display on protx/dash/demographics

## Related Jira tickets: ##

* [COOKS-312](https://jira.tacc.utexas.edu/browse/COOKS-312)

## Summary of Changes: ##
Added DFPS region number to the plot-details-section-selected-label in the DFPS Region area display when a county is selected.

## Testing Steps: ##
1. Open https://cep.test/protx/dash/demographics
2. Navigate to the DFPS area display
3. Click a county
4. Make sure the DFPS region number is displayed.

## UI Photos:
Before changes:
<img width="1727" alt="Screen Shot 2022-10-03 at 10 32 36 AM" src="https://user-images.githubusercontent.com/96220951/193617528-2e0ed325-049e-4678-b363-55ab026ec915.png">

After changes:
<img width="1757" alt="Screen Shot 2022-10-03 at 10 31 02 AM" src="https://user-images.githubusercontent.com/96220951/193617189-4db0df49-4128-4efc-9c58-d08258fc52c2.png">


## Notes: ##
