### PR TITLE
Task/COOKS-317: Remove lat and long from resource download csv file

### DIFF
--- a/protx/tests/api_test.py
+++ b/protx/tests/api_test.py
@@ -124,7 +124,7 @@ def test_get_resources_download(test_client, core_api_workbench_request):
     assert resp.status_code == 200
     assert resp.headers['Content-Disposition'].startswith("attachment; filename=\"Erath_county_resources")
     assert resp.headers['Content-Disposition'].endswith('.csv\"')
-    assert resp.get_data(as_text=True).startswith("NAME,STREET,CITY,STATE,POSTAL_CODE,PHONE,WEBSITE,LATITUDE,LONGITUDE,NAICS_CODE,NAICS_DESCRIPTION")
+    assert resp.get_data(as_text=True).startswith("NAME,STREET,CITY,STATE,POSTAL_CODE,PHONE,WEBSITE,NAICS_CODE,NAICS_DESCRIPTION")
 
 
 def test_get_resources_download_unauthed(test_client, core_api_workbench_request_unauthed):

--- a/protx/utils/resources.py
+++ b/protx/utils/resources.py
@@ -43,7 +43,7 @@ class Echo:
 
 def download_resources(naics_codes, area, geoid):
     """Get resources csv"""
-    download_fields = ["NAME", "STREET", "CITY", "STATE", "POSTAL_CODE", "PHONE", "WEBSITE", "LATITUDE", "LONGITUDE", "NAICS_CODE"]
+    download_fields = ["NAME", "STREET", "CITY", "STATE", "POSTAL_CODE", "PHONE", "WEBSITE", "NAICS_CODE"]
     supported_areas = {"county": {"table": "texas_counties", "geo_identifier": "geo_id", "name": "name"},
                        "tract": {"table": "census_tracts_2019", "geo_identifier": "geoid", "name": "name"},
                        "dfps_region": {"table": "dfps_regions", "geo_identifier": "sheet1__re", "name": "sheet1__re"}}


### PR DESCRIPTION
## Overview: ##
Remove latitude and longitude columns from resource csv download file.

## Related Jira tickets: ##

* [COOKS-123](https://jira.tacc.utexas.edu/browse/COOKS-123)

## Testing Steps: ##
1. Open https://cep.test/protx/dash/demographics
2. Click on a region
3. Click on the blue "Download" button in the selector pane at the top
4. Open the downloaded csv file and ensure that the latitude and longitude columns are removed.

The above testing steps can be repeated for tracts and counties in the demographics view, and for https://cep.test/protx/dash/demographics and https://cep.test/protx/dash/analytics.

## UI Photos:

## Notes: ##
