### PR TITLE
Task/cooks 322 add name to tract view

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -27,7 +27,7 @@ function DemographicsDetails({
       break;
     case 'tract':
       selectedGeographyTypeDisplayLabel = 'Tract: ' ;
-      selectedGeographicFeature = selectedGeographicFeature.slice(-5);
+      selectedGeographicFeature = "(" + selectedGeographicFeature.slice(-6) + ")";
       selectedGeographicFeatureName = "TX - " + selectedGeographicFeatureName + " County";
       geographyType = '';
       break;

--- a/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
+++ b/protx-client/src/components/ProTx/components/charts/DemographicsDetails.jsx
@@ -26,8 +26,9 @@ function DemographicsDetails({
       geographyType = capitalizeString(geography);
       break;
     case 'tract':
-      selectedGeographyTypeDisplayLabel = 'Tract';
-      selectedGeographicFeatureName = '';
+      selectedGeographyTypeDisplayLabel = 'Tract: ' ;
+      selectedGeographicFeature = selectedGeographicFeature.slice(-5);
+      selectedGeographicFeatureName = "TX - " + selectedGeographicFeatureName + " County";
       geographyType = '';
       break;
     case 'dfps_region':

--- a/protx-client/src/components/ProTx/components/shared/dataUtils.js
+++ b/protx-client/src/components/ProTx/components/shared/dataUtils.js
@@ -56,7 +56,21 @@ const getSelectedGeographyName = (geography, currentGeoid) => {
       geographyName = fipsIdName;
       break;
     case 'tract':
-      geographyName = 'tract_placeholder';
+      const trimmedTractGeoid = currentGeoid.slice(2, 5);
+      const tractObjects = PHR_MSA_COUNTIES[0];
+
+      Object.keys(tractObjects).forEach(cty => {
+        const currentCounty = tractObjects[cty];
+        const baseCode = '000';
+        const countyCode = baseCode + currentCounty['FIPS Number']; // String.
+        const currentCountyCode = countyCode.slice(-3);
+        const currentCountyName = currentCounty['County Name'];
+      
+        if (trimmedTractGeoid === currentCountyCode) {
+          fipsIdName = currentCountyName;
+        }
+      });
+      geographyName = fipsIdName;
       break;
     case 'dfps_region':
       // const regionLabel = currentGeoid.slice(2);


### PR DESCRIPTION
## Overview: ##
The census track view needed a more descriptive name. Now renders as Tract: (census track id) TX - (county name) in the plot-details-section-selected in the census track area view on /protx/dash/demographics

## Related Jira tickets: ##

* [COOKS-322](https://jira.tacc.utexas.edu/browse/COOKS-322)

## Summary of Changes: ##
Changed what was returned by getSelectedGeographyName for the tract case in protx-client/src/components/shared/dataUtils.js so that the tract case can return county name.

Sliced fips/geoId number to display only the last 6 digits that identify the census track id number.
Rearranged props in dataUtils and DemographicDetails in protx-client/src/components/ProTX/components to render correctly.

## Testing Steps: ##
1. Go to https://cep.test/protx/dash/demographics
2. Select Census Track area from display selector drop down
3. Click a specific area to zoom
4. Make sure the plot-details-section-selected renders in this format 
Tract: (6 digit track id num) TX - (county name)

## UI Photos:
Before change:
<img width="1643" alt="Screen Shot 2022-10-04 at 8 40 40 AM" src="https://user-images.githubusercontent.com/96220951/193835150-2b44ea43-d23d-460a-ae14-5405fa6c48ca.png">


After change:
<img width="1613" alt="Screen Shot 2022-10-04 at 8 40 18 AM" src="https://user-images.githubusercontent.com/96220951/193834984-7044c429-9d4f-46ee-835b-bb8415a6c33f.png">

## Notes: ##
