### PR TITLE
remove code related to projections selector

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
@@ -7,7 +7,7 @@ import ChartInstructions from "./ChartInstructions";
 import './PlotDetails.css';
 
 
-function AnalyticsStateDistribution({geography, analyticsType}) {
+function AnalyticsStateDistribution({geography}) {
   const dispatch = useDispatch();
 
   const chartData = useSelector(
@@ -19,10 +19,10 @@ function AnalyticsStateDistribution({geography, analyticsType}) {
         type: 'FETCH_PROTX_ANALYTICS_STATEWIDE_DISTRIBUTION',
         payload: {
           area: geography,
-          analyticsType: analyticsType,
+          analyticsType: 'pred_per_100k',
         }
       });
-    }, [geography, analyticsType]);
+    }, [geography]);
 
   if (chartData.error) {
     return (
@@ -57,7 +57,6 @@ function AnalyticsStateDistribution({geography, analyticsType}) {
 
 AnalyticsStateDistribution.propTypes = {
   geography: PropTypes.string.isRequired,
-  analyticsType: PropTypes.string.isRequired
 };
 
 export default AnalyticsStateDistribution;

--- a/protx-client/src/components/ProTx/components/charts/MainChart.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.jsx
@@ -32,7 +32,7 @@ function MainChart({
       );
     } else {
       return (
-        <AnalyticsStateDistribution geography={geography} analyticsType={analyticsType}/>
+        <AnalyticsStateDistribution geography={geography}/>
       );
     }
   }

--- a/protx-client/src/components/ProTx/components/dashboard/DashboardDisplay.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DashboardDisplay.jsx
@@ -31,7 +31,6 @@ function DashboardDisplay() {
     PRESELECTED_MALTREATMENT_CATEGORIES
   );
   const [observedFeature, setObservedFeature] = useState('AGE17');
-  const [analtyicsType, setAnalyticsType] = useState('risk');
   const [year, setYear] = useState(DEFAULT_YEAR);
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
     ''
@@ -226,21 +225,19 @@ function DashboardDisplay() {
         <Route
           path={`${protxRoute}/analytics`}
           render={() => {
-            setMapType('analytics'); //todo; see DisplaySelectors
+            setMapType('analytics');
             return (
               <>
                 <DisplaySelectors
-                  mapType="observedFeatures"
+                  mapType={mapType}
                   geography={geography}
                   maltreatmentTypes={maltreatmentTypes}
                   observedFeature={observedFeature}
-                  analyticsType={analtyicsType}
                   year={year}
                   unit={unit}
                   selectedGeographicFeature={selectedGeographicFeature}
                   setMaltreatmentTypes={setMaltreatmentTypes}
                   setObservedFeature={setObservedFeature}
-                  setAnalyticsType={setAnalyticsType}
                   downloadResources={handleDownloadResources}
                 />
                 <div className="display-layout-root">
@@ -269,7 +266,6 @@ function DashboardDisplay() {
                       geography={geography}
                       maltreatmentTypes={maltreatmentTypes}
                       observedFeature={observedFeature}
-                      analyticsType={analtyicsType}
                       year={year}
                       selectedGeographicFeature={selectedGeographicFeature}
                       data={data}

--- a/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
@@ -78,14 +78,12 @@ function DisplaySelectors({
   geography,
   maltreatmentTypes,
   observedFeature,
-  analyticsType,
   year,
   unit,
   selectedGeographicFeature,
   setGeography,
   setMaltreatmentTypes,
   setObservedFeature,
-  setAnalyticsType,
   setYear,
   setUnit,
   limitToTopObservedFeatureFields,
@@ -100,7 +98,6 @@ function DisplaySelectors({
   const valueRadioBtn1 =
     mapType === 'maltreatment' ? 'rate_per_100k_under17' : 'count';
   const display = useSelector(state => state.protx.data.display);
-  const analyticsCategories = [{name: 'risk', display_text: 'Relative Risk'}, {name: 'pred_per_100k', display_text: 'Predicted Number of Cases'}]
 
   const changeUnit = newUnit => {
     if (mapType === 'observedFeatures') {
@@ -206,24 +203,6 @@ function DisplaySelectors({
           </div>
         </>
       )}
-      {(mapType === 'analytics') && (
-        <>
-          <div className={styles["control"]}>
-            <span className={styles["label"]}>Projections</span>
-            <DropdownSelector
-              value={analyticsType}
-              onChange={(event) => setAnalyticsType(event.target.value)}>
-              <optgroup label="Select projection type">
-                {analyticsCategories.map(type => (
-                  <option key={type.name} value={type.name}>
-                    {type.display_text}
-                  </option>
-                ))}
-              </optgroup>
-            </DropdownSelector>
-          </div>
-        </>
-      )}
       <div className={styles["control"]}>
         <span className={styles["label"]}>Years</span>
         <DropdownSelector
@@ -258,14 +237,12 @@ DisplaySelectors.propTypes = {
   geography: PropTypes.string.isRequired,
   maltreatmentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   observedFeature: PropTypes.string.isRequired,
-  analyticsType: PropTypes.string,
   year: PropTypes.string.isRequired,
   unit: PropTypes.string.isRequired,
   selectedGeographicFeature: PropTypes.string.isRequired,
   setGeography: PropTypes.func,
   setMaltreatmentTypes: PropTypes.func.isRequired,
   setObservedFeature: PropTypes.func.isRequired,
-  setAnalyticsType: PropTypes.func,
   setYear: PropTypes.func,
   setUnit: PropTypes.func,
   limitToTopObservedFeatureFields: PropTypes.bool,
@@ -273,9 +250,7 @@ DisplaySelectors.propTypes = {
 };
 
 DisplaySelectors.defaultProps = {
-  analyticsType: null,
   setGeography: null,
-  setAnalyticsType: null,
   setYear: null,
   setUnit: null,
   limitToTopObservedFeatureFields: false

--- a/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
@@ -203,21 +203,22 @@ function DisplaySelectors({
           </div>
         </>
       )}
-      <div className={styles["control"]}>
-        <span className={styles["label"]}>Years</span>
-        <DropdownSelector
-          value={year}
-          onChange={(event) => setYear(event.target.value)}
-          disabled={disabledYear}>
-          <optgroup label="Select year" />
-          {SUPPORTED_YEARS.map((y) => (
-            <option key={y} value={y}>
-              {y}
-            </option>
-          ))}
-        </DropdownSelector>
-      </div>
-
+      {(mapType !== 'analytics') && (
+        <div className={styles["control"]}>
+          <span className={styles["label"]}>Years</span>
+          <DropdownSelector
+            value={year}
+            onChange={(event) => setYear(event.target.value)}
+            disabled={disabledYear}>
+            <optgroup label="Select year" />
+            {SUPPORTED_YEARS.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </DropdownSelector>
+        </div>
+      )}
       {selectedGeographicFeature && (
         <Button
           onClick={downloadResources}


### PR DESCRIPTION
## Overview: ##
Remove Projections selector

## Related Jira tickets: ##

* [COOKS-123](https://jira.tacc.utexas.edu/browse/COOKS-123)

## Summary of Changes: ##
Remove frontend code related to the Projections selector

## Testing Steps: ##
1. Go to https://cep.test/protx/dash/analytics
2. Make sure there is no Projections dropdown menu, no Demographics dropdown menu, and no Year dropdown menu.
3. Make sure the correct chart is shown on the right; it needs to be the chart with 'Predicted Number of Cases per 100K persons' as the x-axis label.

## UI Photos:
![Screen Shot 2022-10-20 at 4 17 13 PM](https://user-images.githubusercontent.com/79928051/197060222-74e9712d-6ee6-456c-a1f4-f49f39666ff9.png)

## Notes: ##
