### PR TITLE
Add county chart with red line

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/AnalyticsPredictiveTable.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsPredictiveTable.jsx
@@ -26,11 +26,6 @@ function AnalyticsPredictiveTable({geography, selectedGeographicFeature}) {
   );
   const showPlot = false; // Hide the plot while in dev.
 
-  const plotState = {
-    data: [{ type: 'bar', x: [1, 2, 3], y: [1, 3, 2] }],
-    layout: { title: { text: 'Analytics' } }
-  };
-
   if(analytics.error) {
     return (
       <div>something went wrong</div>
@@ -58,7 +53,7 @@ function AnalyticsPredictiveTable({geography, selectedGeographicFeature}) {
     </div>
   );
   */
-
+  console.log(analytics.chartData)
   return (
     <div className="predictive-features-chart">
       <div className="predictive-features-plot">
@@ -66,17 +61,7 @@ function AnalyticsPredictiveTable({geography, selectedGeographicFeature}) {
           <PredictiveFeaturesTable
             selectedGeographicFeature={selectedGeographicFeature}
           />
-          {showPlot && (
-            <>
-              <AnalyticsDetails
-                geography={geography}
-                observedFeature={observedFeature}
-                selectedGeographicFeature={selectedGeographicFeature}
-                data={data}
-              />
-              <MainPlot plotState={plotState} />
-            </>
-          )}
+          <MainPlot plotState={analytics.chartData} />
           <ChartInstructions currentReportType="hidden" />
         </div>
       </div>

--- a/protx-client/src/components/ProTx/components/dashboard/DashboardDisplay.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DashboardDisplay.jsx
@@ -230,7 +230,7 @@ function DashboardDisplay() {
             return (
               <>
                 <DisplaySelectors
-                  mapType="observedFeatures"
+                  mapType={mapType}
                   geography={geography}
                   maltreatmentTypes={maltreatmentTypes}
                   observedFeature={observedFeature}

--- a/protx-client/src/redux/reducers/protx.reducers.js
+++ b/protx-client/src/redux/reducers/protx.reducers.js
@@ -92,9 +92,10 @@ export function protxMaltreatmentDistribution(
 }
 
 export const initialAnalyticsState = {
-  loading: false,
+  loading: true,
   error: false,
-  data: null
+  data: null,
+  chartData: null
 };
 
 export function protxAnalytics(
@@ -111,6 +112,7 @@ export function protxAnalytics(
       return {
         ...state,
         data: action.payload.data,
+        chartData: action.payload.chartData,
         loading: false
       };
     case 'PROTX_ANALYTICS_FAILURE':
@@ -126,7 +128,7 @@ export function protxAnalytics(
 export const initialAnalyticsStatewideDistributionState = {
   loading: true,
   error: false,
-  data: null
+  data: null,
 };
 
 export function protxAnalyticsStatewideDistribution(

--- a/protx-client/src/redux/sagas/protx.sagas.js
+++ b/protx-client/src/redux/sagas/protx.sagas.js
@@ -112,7 +112,8 @@ export function* fetchProtxAnalytics(action) {
     yield put({
       type: 'PROTX_ANALYTICS_SUCCESS',
       payload: {
-        data: data.result
+        data: data.result,
+        chartData: data.chartData
       }
     });
   } catch (error) {
@@ -131,7 +132,7 @@ export function* fetchProtxAnalyticsStatewideDistribution(action) {
     yield put({
       type: 'PROTX_ANALYTICS_STATEWIDE_DISTRIBUTION_SUCCESS',
       payload: {
-        data: data.result
+        data: data.result,
       }
     });
   } catch (error) {

--- a/protx/api.py
+++ b/protx/api.py
@@ -133,7 +133,7 @@ class AnalyticsSubset(Resource):
                 chartData = analytics.get_distribution_prediction_plot_(data, pred_per_100k)
                 return {"result": dict(result), "chartData": chartData}
             except NoResultFound:
-                chartData = analytics.get_distribution_prediction_plot_(data)
+                chartData = analytics.get_distribution_prediction_plot_(data, 'no data')
                 return {"result": {"GEOID": int(geoid)}, "chartData": chartData}
 
 

--- a/protx/api.py
+++ b/protx/api.py
@@ -123,10 +123,13 @@ class AnalyticsSubset(Resource):
 
         """
         logger.info(f"Getting analytics data for {area} {geoid}")
+        data = analytics.read_sqlite(analytics_db)
         engine = create_engine(SQLALCHEMY_RESOURCES_ANALYTICS_URL, connect_args={'check_same_thread': False})
         with engine.connect() as connection:
             result = connection.execute(f"SELECT * FROM predictions p WHERE p.GEOID={geoid} AND p.GEOTYPE='{area}'").one()
-            return {"result": dict(result)}
+            pred_per_100k = result['pred_per_100k']
+            chartData = analytics.get_distribution_prediction_plot_(data, pred_per_100k)
+            return {"result": dict(result), "chartData": chartData}
 
 
 @api.route("/analytics-chart/<area>/<analytics_type>/")

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -65,6 +65,7 @@ def get_distribution_risk_plot(data):
                        text=_high_risk_label,
                        showarrow=False,
                        font={'size': 20, 'color': _high_risk_color})
+    fig.update_traces(marker_color=_histogram_color)
     return json.loads(fig.to_json())
 
 
@@ -115,4 +116,5 @@ def get_distribution_prediction_plot_(data):
                        text=_high_risk_label,
                        showarrow=False,
                        font={'size': 20, 'color': _high_risk_color})
+    fig.update_traces(marker_color=_histogram_color)
     return json.loads(fig.to_json())

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -90,19 +90,36 @@ def get_distribution_prediction_plot_(data, predictedNum=None):
                       xbins=go.histogram.XBins(size=50)
                       )
 
+    if predictedNum is None:
+        fig.update_layout(
+            title={
+                'text': "Definition of Risk Levels",
+                'y': 0.9,
+                'x': 0.5,
+                'xanchor': 'center',
+                'yanchor': 'top'},
+            )
+    elif predictedNum == 'no data':
+        fig.update_layout(
+            title={
+                'text': "No Data Available",
+                'y': 0.9,
+                'x': 0.5,
+                'xanchor': 'center',
+                'yanchor': 'top'},
+            )
+    else:
+        fig.update_layout(
+            margin=dict(t=25)
+        )
+
     fig.update_layout(
-        title={
-            'text': "Definition of Risk Levels",
-            'y': 0.9,
-            'x': 0.5,
-            'xanchor': 'center',
-            'yanchor': 'top'},
         xaxis_title="Predicted Number of Cases per 100K persons",
         yaxis_title="Frequency",
         font=dict(
             size=18,
             color="Black"
-        )
+        ),
     )
     fig.update_xaxes(range=[0, data['predictions'].pred_per_100k.max()+50])
     fig.add_annotation(x=30,

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -80,7 +80,10 @@ def get_distribution_prediction_plot_(data):
     fig.add_vline(x=mean+std, line_width=3, line_dash="dash", line_color="black")
     fig.add_vline(x=mean-std, line_width=3, line_dash="dash", line_color="black")
 
-    fig.add_histogram(x=data['predictions']['pred_per_100k'], nbinsx=20)
+    fig.add_histogram(x=data['predictions']['pred_per_100k'],
+                      # nbinsx=50,
+                      xbins=go.histogram.XBins(size=50)
+                      )
 
     fig.update_layout(
         title={

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -45,7 +45,6 @@ def get_distribution_risk_plot(data):
         xaxis_title="Relative Risk",
         yaxis_title="Frequency",
         font=dict(
-            family="Times New Roman, monospace",
             size=18,
             color="Black"
         )
@@ -95,7 +94,6 @@ def get_distribution_prediction_plot_(data):
         xaxis_title="Predicted Number of Cases per 100K persons",
         yaxis_title="Frequency",
         font=dict(
-            family="Times New Roman, monospace",
             size=18,
             color="Black"
         )

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -14,10 +14,13 @@ _low_risk_label = "Low <br>Risk"
 _medium_risk_label = "Medium <br>Risk"
 _high_risk_label = "High <br>Risk"
 
-_low_risk_color = "green"
-_medium_risk_color = "yellow"
-_high_risk_color = "red"
-
+# colors should eventually match colors in 4 classes in frontend (specificaly data/colors.js
+# but see https://jira.tacc.utexas.edu/browse/COOKS-329 for details but currently in css overrides
+# in ProtxColors.css
+_low_risk_color = "#c6e8b0"
+_medium_risk_color = "#8fcca1"
+_high_risk_color = "#62ad9c"
+_histogram_color = "#26547a" # "#924e8c"
 
 def read_sqlite(dbfile):
     with sqlite3.connect(dbfile) as dbcon:

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -22,9 +22,6 @@ def get_distribution_risk_plot(data):
     """ Get plot of for distribution of risk and levels for high, medium, low risk based on column 'risk'
     """
     fig = go.Figure()
-    fig.add_vrect(x0=1, x1=4, line_width=0, fillcolor="red", opacity=0.05)
-    fig.add_vrect(x0=-1, x1=1, line_width=0, fillcolor="yellow", opacity=0.05)
-    fig.add_vrect(x0=-4, x1=-1, line_width=0, fillcolor="green", opacity=0.05)
     fig.add_vline(x=1, line_width=3, line_dash="dash", line_color="black")
     fig.add_vline(x=-1, line_width=3, line_dash="dash", line_color="black")
 
@@ -62,21 +59,10 @@ def get_distribution_prediction_plot_(data):
 
     """
 
-    # compute thresholds
     mean = data['predictions'].pred_per_100k.mean()
     std = data['predictions'].pred_per_100k.std()
 
-    # instantiate figure
     fig = go.Figure()
-    fig.add_vrect(x0=mean+std,
-                  x1=data['predictions'].pred_per_100k.max()+50,
-                  line_width=0, fillcolor="red", opacity=0.05)
-    fig.add_vrect(x0=mean-std,
-                  x1=mean+std,
-                  line_width=0, fillcolor="yellow", opacity=0.05)
-    fig.add_vrect(x0=data['predictions'].pred_per_100k.min()-50,
-                  x1=mean-std,
-                  line_width=0, fillcolor="green", opacity=0.05)
     fig.add_vline(x=mean+std, line_width=3, line_dash="dash", line_color="black")
     fig.add_vline(x=mean-std, line_width=3, line_dash="dash", line_color="black")
 

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -10,6 +10,14 @@ import json
 from pandas import read_sql_query
 import plotly.graph_objects as go
 
+_low_risk_label = "Low <br>Risk"
+_medium_risk_label = "Medium <br>Risk"
+_high_risk_label = "High <br>Risk"
+
+_low_risk_color = "green"
+_medium_risk_color = "yellow"
+_high_risk_color = "red"
+
 
 def read_sqlite(dbfile):
     with sqlite3.connect(dbfile) as dbcon:
@@ -35,20 +43,26 @@ def get_distribution_risk_plot(data):
             'xanchor': 'center',
             'yanchor': 'top'},
         xaxis_title="Relative Risk",
-        yaxis_title="Frequency")
+        yaxis_title="Frequency",
+        font=dict(
+            family="Times New Roman, monospace",
+            size=18,
+            color="Black"
+        )
+    )
 
     fig.add_annotation(x=-3, y=30,
-                       text="Low Risk",
+                       text=_low_risk_label,
                        showarrow=False,
-                       font={'size': 16, 'color': 'green'})
+                       font={'size': 20, 'color': _low_risk_color})
     fig.add_annotation(x=-0, y=30,
-                       text="Medium Risk ",
+                       text=_medium_risk_label,
                        showarrow=False,
-                       font={'size': 16, 'color': 'yellow'})
+                       font={'size': 20, 'color': _medium_risk_color})
     fig.add_annotation(x=3, y=30,
-                       text="High Risk",
+                       text=_high_risk_label,
                        showarrow=False,
-                       font={'size': 16, 'color': 'red'})
+                       font={'size': 20, 'color': _high_risk_color})
     return json.loads(fig.to_json())
 
 
@@ -76,19 +90,25 @@ def get_distribution_prediction_plot_(data):
             'xanchor': 'center',
             'yanchor': 'top'},
         xaxis_title="Predicted Number of Cases per 100K persons",
-        yaxis_title="Frequency")
+        yaxis_title="Frequency",
+        font=dict(
+            family="Times New Roman, monospace",
+            size=18,
+            color="Black"
+        )
+    )
     fig.update_xaxes(range=[0, data['predictions'].pred_per_100k.max()+50])
     fig.add_annotation(x=30,
                        y=30,
-                       text="Low Risk",
+                       text=_low_risk_label,
                        showarrow=False,
-                       font={'size': 16, 'color': 'green'})
+                       font={'size': 20, 'color': _low_risk_color})
     fig.add_annotation(x=mean-0*std, y=30,
-                       text="Medium Risk ",
+                       text=_medium_risk_label,
                        showarrow=False,
-                       font={'size': 16, 'color': 'yellow'})
+                       font={'size': 20, 'color': _medium_risk_color})
     fig.add_annotation(x=mean+2*std, y=30,
-                       text="High Risk",
+                       text=_high_risk_label,
                        showarrow=False,
-                       font={'size': 16, 'color': 'red'})
+                       font={'size': 20, 'color': _high_risk_color})
     return json.loads(fig.to_json())

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -69,7 +69,7 @@ def get_distribution_risk_plot(data):
     return json.loads(fig.to_json())
 
 
-def get_distribution_prediction_plot_(data):
+def get_distribution_prediction_plot_(data, predictedNum=None):
     """ Get plot of for distribution of risk and levels for high, medium, low risk based on column pred_per_100k column
 
     The pred_per_100k columns represents what our models predicted as the number of cases per 100K people
@@ -82,6 +82,8 @@ def get_distribution_prediction_plot_(data):
     fig = go.Figure()
     fig.add_vline(x=mean+std, line_width=3, line_dash="dash", line_color="black")
     fig.add_vline(x=mean-std, line_width=3, line_dash="dash", line_color="black")
+    if predictedNum:
+        fig.add_vline(x=predictedNum, line_width=3, line_color="red")
 
     fig.add_histogram(x=data['predictions']['pred_per_100k'],
                       # nbinsx=50,


### PR DESCRIPTION
## Overview: ##
Display a county chart with a red line indicating predicted cases per 100k persons for that selected county.

## Related Jira tickets: ##

* [COOKS-123](https://jira.tacc.utexas.edu/browse/COOKS-123)

## Summary of Changes: ##
Made changes to backend logic and plotly charts and frontend redux code and components

## Testing Steps: ##
1. Go to https://cep.test/protx/dash/analytics
2. Click on several different counties, each with different risk levels, and observe the new county charts having their red lines move accordingly.
3. Click on a county chart without any data and check the new county chart.

## UI Photos:

## Notes: ##
