### PR TITLE
Fix/update colors and analytics colorbar

### DIFF
--- a/protx-client/src/components/ProTx/components/data/colors.js
+++ b/protx-client/src/components/ProTx/components/data/colors.js
@@ -12,11 +12,11 @@ const colorbrewerClassYlOrBr = {
   repeat values defined for 6 classes as these are overridden in ProtxColors.css
   with updated values.  We really should just update the values here.
    */
-  5: ['#ffffd4', '#fee391', '#fec44f', '#fe9929', '#d95f0e'],
+  5: ['#ffffd4', '#fee391', '#fec44f', '#fe9929', '#993404'],
 
-  4: ['#ffffd4', '#fee391', '#fec44f', '#fe9929'],
-  3: [`#ffffd4`, `#fee391`, `#fec44f`],
-  2: [`#ffffd4`, `#fee391`],
+  4: ['#ffffd4', '#fee391', '#fe9929', '#993404'],
+  3: [`#ffffd4`, `#fec44f`, `#993404`],
+  2: [`#ffffd4`, `#993404`],
   1: [`#ffffd4`]
 };
 

--- a/protx-client/src/components/ProTx/components/maps/MainMap.jsx
+++ b/protx-client/src/components/ProTx/components/maps/MainMap.jsx
@@ -193,8 +193,7 @@ function MainMap({
           {key: 'low', label: 'Low'},
           {key:'medium ', label:'Medium'}, // 'medium ' with space; check DB
           {key: 'high', label: 'High'}];
-        const missingLabel = "No forecast";
-        newColorScale = new CategoryColorScale(categories, missingLabel);
+        newColorScale = new CategoryColorScale(categories);
       } else {
         const meta = getMetaData(
           data,


### PR DESCRIPTION
## Overview: ##

Update colors on map and remove the "No forecast" class.

Chart colors are updated in https://github.com/TACC/protx-dashboard/pull/50

## Related Jira tickets: ##

* [COOKS-324](https://jira.tacc.utexas.edu/browse/COOKS-324)

## Testing Steps: ##
1. View map and ensure that new colors are used and "No forecast" class is gone

## UI Photos:
![Screen Shot 2022-10-21 at 8 07 07 AM](https://user-images.githubusercontent.com/8287580/197203345-47d1694d-fe00-4a82-a325-eb9eb46a94ec.png)
