### PR TITLE
Subtask - align table to center of plot section

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/AnalyticsPredictiveTable.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsPredictiveTable.jsx
@@ -46,12 +46,13 @@ function AnalyticsPredictiveTable({geography, selectedGeographicFeature}) {
     );
   }
 
+  //Gets human-readable string from DB
   const countyName = getSelectedGeographyName(geography, analytics.data.GEOID.toString());
 
   const observedFeaturesLabel_1 = analytics.data.demographic_feature_1 ? getObservedFeaturesLabel(analytics.data.demographic_feature_1, data) : '--No Data--'
   const observedFeaturesLabel_2 = analytics.data.demographic_feature_2 ? getObservedFeaturesLabel(analytics.data.demographic_feature_2, data) : '--No Data--'
   const observedFeaturesLabel_3 = analytics.data.demographic_feature_3 ? getObservedFeaturesLabel(analytics.data.demographic_feature_3, data) : '--No Data--'
-  
+
   const correlation_1 = analytics.data.correlation_1 ? capitalizeString(analytics.data.correlation_1) : '--No Data--';
   const correlation_2 = analytics.data.correlation_2 ? capitalizeString(analytics.data.correlation_2) : '--No Data--';
   const correlation_3 = analytics.data.correlation_3 ? capitalizeString(analytics.data.correlation_3) : '--No Data--';
@@ -60,14 +61,12 @@ function AnalyticsPredictiveTable({geography, selectedGeographicFeature}) {
   
   const analyticsFeatureTitle = () => {
     return (
-      <div className="feature-table-chart-selection">
         <div className="feature-table-chart-title">
         Top Three Maltreatment Factors for {countyName} County
           <span className="feature-table-chart-subtitle">
             ({chartSubtitle})
           </span>
         </div>
-      </div>
     );
   };
 
@@ -97,41 +96,41 @@ function AnalyticsPredictiveTable({geography, selectedGeographicFeature}) {
             </span>
           </div>
         </div>
-      <div className="feature-table">
-        <div className="feature-table-chart-selection">
-          <div> {analyticsChartTitle} 
-            <table>
-              <thead>{analyticsFeatureTableHeader}</thead>
-              <tbody>
-                <tr>
-                  <td>{"1"}</td>
-                  <td className="ensemble-rank-value">
-                    {observedFeaturesLabel_1}
-                  </td>
-                  <td>{correlation_1}</td>
-                </tr>
-                <tr>
-                  <td>{"2"}</td>
-                  <td className="ensemble-rank-value">
-                    {observedFeaturesLabel_2}
-                  </td>
-                  <td>{correlation_2}</td>
-                </tr>
-                <tr>
-                  <td>{"3"}</td>
-                  <td className="ensemble-rank-value">
-                    {observedFeaturesLabel_3}
-                  </td>
-                  <td>{correlation_3}</td>
-                </tr>
-              </tbody>
-            </table>
+        <div className="feature-table">
+          <div className="feature-table-chart-selection">
+            <div className="plot-detai"> {analyticsChartTitle} 
+              <table>
+                <thead>{analyticsFeatureTableHeader}</thead>
+                <tbody>
+                  <tr>
+                    <td>{"1"}</td>
+                    <td className="ensemble-rank-value">
+                      {observedFeaturesLabel_1}
+                    </td>
+                    <td>{correlation_1}</td>
+                  </tr>
+                  <tr>
+                    <td>{"2"}</td>
+                    <td className="ensemble-rank-value">
+                      {observedFeaturesLabel_2}
+                    </td>
+                    <td>{correlation_2}</td>
+                  </tr>
+                  <tr>
+                    <td>{"3"}</td>
+                    <td className="ensemble-rank-value">
+                      {observedFeaturesLabel_3}
+                    </td>
+                    <td>{correlation_3}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
           <ChartInstructions currentReportType="analyticsCountyFeatureChart"></ChartInstructions>
           <ChartInstructions currentReportType="hidden"></ChartInstructions>
+        </div>
       </div>
-    </div>
     );
   };
 

--- a/protx-client/src/components/ProTx/components/charts/ChartInstructions.jsx
+++ b/protx-client/src/components/ProTx/components/charts/ChartInstructions.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import './ChartInstructions.css';
+import './PredictiveFeaturesTable.css';
+
 
 function ChartInstructions({ currentReportType }) {
   const instructions = {
@@ -135,19 +137,17 @@ function ChartInstructions({ currentReportType }) {
 
   if (currentReportType === 'analyticsCountyFeatureChart') {
     return (
-      <div className="feature-table-chart-selection">
-        <div className='report-instructions-description'>
-          <td className="feature-table-annotation-prefix">
-            Table 1</td>
-          <div className="feature-table-annotation-text">
-          Top three demographic features related to changes in the county-level child 
-          total maltreatment counts. Ranking indicates features that are most influential. 
-          Correlation indicates the nature of the relationship between the demographic 
-          feature and total maltreatment counts. A positive correlation implies that an 
-          increase in the demographic feature results in an increase in total maltreatment 
-          counts and vice versa. A negative correlation means an increase in the demographic 
-          feature results in a decrease in total maltreatment counts.</div>
-        </div>
+      <div className='report-instructions-description'>
+        <div className="feature-table-annotation-prefix">
+          Table 1</div>
+        <div className="feature-table-annotation-text">
+        Top three demographic features related to changes in the county-level child 
+        total maltreatment counts. Ranking indicates features that are most influential. 
+        Correlation indicates the nature of the relationship between the demographic 
+        feature and total maltreatment counts. A positive correlation implies that an 
+        increase in the demographic feature results in an increase in total maltreatment 
+        counts and vice versa. A negative correlation means an increase in the demographic 
+        feature results in a decrease in total maltreatment counts.</div>
       </div>
     );
   }

--- a/protx-client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
+++ b/protx-client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
@@ -1,6 +1,7 @@
 .feature-table * {
   font-family: var(--font-type-roboto-condensed);
   font-size: var(--font-size-xs);
+  margin: 0.8vh 1vw 0.5vh;
 }
 sup {
   font-style: italic;
@@ -67,11 +68,13 @@ sup {
   padding-left: 2vw;
   text-align: left;
 }
+
 .feature-table-chart-label {
-  width: 37%;
+  width: 20%;
 }
+
 .feature-table-chart-cell {
-  width: 12%;
+  width: 5%;
 }
 .feature-table-info * {
   font-weight: var(--font-weight-light);


### PR DESCRIPTION
## Overview: ##
https://github.com/TACC/protx-dashboard/pull/51
Add on from PR above to center table

## Related Jira tickets: ##

* [COOKS-335](https://jira.tacc.utexas.edu/browse/COOKS-335)
* [COOKS-328](https://jira.tacc.utexas.edu/browse/COOKS-328)

## Summary of Changes: ##
Centered table and adjusted some css classes 
## Testing Steps: ##
1. Go to https://cep.test/protx/dash/analytics
2. Make sure the chart is aligned correctly

## UI Photos:
Display with no data
<img width="1790" alt="Screen Shot 2022-10-20 at 5 32 16 PM" src="https://user-images.githubusercontent.com/96220951/197074570-2ef1fcfe-a7df-4b34-9e2f-6dba96dc4bc7.png">

Display with data
<img width="1780" alt="Screen Shot 2022-10-20 at 5 31 57 PM" src="https://user-images.githubusercontent.com/96220951/197074590-eed8b546-b626-4865-923a-6670c3c7366a.png">

## Notes: ##
