### PR TITLE
task/COOKS-315:  update the maping from the changed display name to its color

### DIFF
--- a/protx/utils/maltreatment.py
+++ b/protx/utils/maltreatment.py
@@ -6,6 +6,7 @@ from protx.log import logger
 
 db_name = '/protx-data/cooks.db'
 
+# TODO.  this should be a mapping that doesn't use display names https://jira.tacc.utexas.edu/browse/COOKS-336
 maltrt_palette = {
     'Abandonment': '#001e2e',
     'Emotional abuse': '#003b5c',
@@ -14,7 +15,7 @@ maltrt_palette = {
     'Neglectful supervision': '#41748d',
     'Physical abuse': '#a9c47f',
     'Physical neglect': '#b9d3dc',
-    'Refusal to accept parental responsibility': '#d4ec8e',
+    'Parental Responsibility Refused': '#d4ec8e',
     'Sexual abuse': '#CCCC99',
     'Sex trafficking': '#eaf6c7'
 }


### PR DESCRIPTION
## Overview: ##

Update display text used in mapping maltreatment types to color.  

## Related Jira tickets: ##

* [COOKS-315](https://jira.tacc.utexas.edu/browse/COOKS-315)

## UI Photos:
![Screen Shot 2022-10-21 at 4 34 02 PM](https://user-images.githubusercontent.com/8287580/197292234-0b07450b-1740-4bc4-9a10-ccb8ed61c1df.png)

![Screen Shot 2022-10-21 at 4 33 39 PM](https://user-images.githubusercontent.com/8287580/197292174-66a9b38a-12e9-4281-885a-e7f7013a992a.png)
