### PR TITLE
Stop graph from bleeding to edge

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/MainChart.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.jsx
@@ -27,8 +27,6 @@ function MainChart({
   if (chartType === 'analytics') {
     const plotDetailSectionTitle = selectedGeographicFeature ? `${getSelectedGeographyName(geography, selectedGeographicFeature)}  County`: "Texas Statewide Data";
     return (
-      <div className="analytics-chart">
-        <div className="analytics-types-plot">
           <div className="analytics-types-plot-layout">
             <div className="plot-details-section">
               <div className="plot-details-section-selected">
@@ -46,8 +44,7 @@ function MainChart({
 
         <ChartInstructions currentReportType={selectedGeographicFeature ? "hidden" : "analytics"}/>
           </div>
-        </div>
-      </div>);
+    );
   }
 
   // DEMOGRAPHICS PLOT.

--- a/protx-client/src/components/ProTx/components/charts/MainPlot.css
+++ b/protx-client/src/components/ProTx/components/charts/MainPlot.css
@@ -14,6 +14,5 @@
   font-family: var(--font-type-roboto-condensed);
 }
 .main-plot {
-  margin: 0 1vw;
-  width: 100%;
+  margin: 1vh 1vw 3.7vh;
 }


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

## Summary of Changes: ##
Put graph in the same div as the rest of the plot-details-section so graph will not bleed to edge

## Testing Steps: ##
1. Go to [https://cep.test/protx/dash/analytics](https://cep.test/protx/dash/analytics)
2. Make sure graph doesn't bleed to edge

## UI Photos:
![](https://files.slack.com/files-pri/T03EBR1EB-F047FDL7W8N/screen_shot_2022-10-21_at_4.27.51_pm.png)


## Notes: ##
