### PR TITLE
Hotfix/COOKS-338: fix plot instruction red line conditional

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
@@ -36,7 +36,7 @@ function AnalyticsStateDistribution({geography, selectedGeographicFeature}) {
       });
   }, [geography, selectedGeographicFeature]);
 
-  if (chartData.error) {
+  if (chartData.error || analytics.error) {
     return (
       <div className="data-error-message">
         There was a problem loading the data.
@@ -44,7 +44,7 @@ function AnalyticsStateDistribution({geography, selectedGeographicFeature}) {
     );
   }
 
-  if (chartData.loading) {
+  if (chartData.loading || (selectedGeographicFeature && analytics.loading)) {
     return (
       <div className="loading-spinner">
         <LoadingSpinner />
@@ -58,7 +58,7 @@ function AnalyticsStateDistribution({geography, selectedGeographicFeature}) {
   medium and low risk regions for heat map on the left.`]
 
   if (selectedGeographicFeature) {
-    if (analytics.data && analytics.data.pred_per_100k) {
+    if (analytics.data.pred_per_100k) {
         plotCaptionText.push([`The red vertical line indicates 
         where `, <span className='annotation-text-bold'>{countyName} County</span>, ` falls on this distribution.`]);
     } else {

--- a/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
@@ -15,19 +15,15 @@ function AnalyticsStateDistribution({geography, selectedGeographicFeature}) {
   const chartData = useSelector(
     state => state.protxAnalyticsStatewideDistribution
   );
+
+  const analytics = useSelector(
+    state => state.protxAnalytics
+  );
   
   let countyName;
   if (selectedGeographicFeature) {
     countyName = getSelectedGeographyName(geography, selectedGeographicFeature)
   }
-
-  const plotLabel = 'Figure 1.';
-  const plotCaptionText = selectedGeographicFeature ? 
-  [`Distribution of projected number of cases across counties in Texas. Black vertical lines indicate thresholds used to define high, 
-  medium and low risk regions for heat map on the left. The red vertical line indicates where `, <span className='annotation-text-bold'>{countyName} County</span>, ` falls on this distribution.`] 
-  : [`Distribution of projected number of cases across counties in Texas. 
-  Black vertical lines indicate thresholds used to define high, medium and low risk regions for heat map 
-  on the left.`];
 
   useEffect(() => {
       dispatch({
@@ -38,7 +34,7 @@ function AnalyticsStateDistribution({geography, selectedGeographicFeature}) {
           geoid: selectedGeographicFeature
         }
       });
-    }, [geography, selectedGeographicFeature]);
+  }, [geography, selectedGeographicFeature]);
 
   if (chartData.error) {
     return (
@@ -56,7 +52,21 @@ function AnalyticsStateDistribution({geography, selectedGeographicFeature}) {
     );
   }
 
+  const plotLabel = 'Figure 1.';
+  let plotCaptionText = [`Distribution of projected number of cases across counties in Texas. 
+  Black vertical lines indicate thresholds used to define high, 
+  medium and low risk regions for heat map on the left.`]
 
+  if (selectedGeographicFeature) {
+    if (analytics.data && analytics.data.pred_per_100k) {
+        plotCaptionText.push([`The red vertical line indicates 
+        where `, <span className='annotation-text-bold'>{countyName} County</span>, ` falls on this distribution.`]);
+    } else {
+      plotCaptionText.push([
+        <span className='annotation-text-bold'> Note: There is no data for {countyName} County.</span>,
+      ]);
+    }
+  }
 
   return (
     <div class="maltreatment-types-plot-layout">

--- a/protx-client/src/components/ProTx/components/charts/FigureCaption.jsx
+++ b/protx-client/src/components/ProTx/components/charts/FigureCaption.jsx
@@ -12,6 +12,6 @@ export const FigureCaption = ({label, captionText}) =>
 
 FigureCaption.propTypes = {
     label: PropTypes.string.isRequired,
-    captionText: PropTypes.string.isRequired,
+    captionText: PropTypes.array.isRequired,
 };
   

--- a/protx/utils/maltreatment.py
+++ b/protx/utils/maltreatment.py
@@ -6,6 +6,7 @@ from protx.log import logger
 
 db_name = '/protx-data/cooks.db'
 
+# TODO.  this should be a mapping that doesn't use display names https://jira.tacc.utexas.edu/browse/COOKS-336
 maltrt_palette = {
     'Abandonment': '#001e2e',
     'Emotional abuse': '#003b5c',
@@ -14,7 +15,7 @@ maltrt_palette = {
     'Neglectful supervision': '#41748d',
     'Physical abuse': '#a9c47f',
     'Physical neglect': '#b9d3dc',
-    'Refusal to accept parental responsibility': '#d4ec8e',
+    'Parental Responsibility Refused': '#d4ec8e',
     'Sexual abuse': '#CCCC99',
     'Sex trafficking': '#eaf6c7'
 }


### PR DESCRIPTION
## Overview: ##
Made analytics plot instructions conditional on whether county analytics data is available.

## Related Jira tickets: ##

* [COOKS-338](https://jira.tacc.utexas.edu/browse/COOKS-338)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to https://cep.test/protx/dash/analytics
2. Click on a county that is colored white (i.e. no analytics data available).
3. Ensure that the analytics plot instructions no longer mention a red line and instead say that the county does not have data.
4. Ensure that the plot instruction for a county with data is correct.
5. Ensure that the plot instructions are correct when no county is selected.

## UI Photos:
![Screen Shot 2022-10-24 at 10 34 46 AM](https://user-images.githubusercontent.com/79928051/197566459-bd4fb719-786e-4db1-beb7-af52338ebb2e.png)

## Notes: ##
