### PR TITLE
Task/COOKS-337 fix sizing issues with analytics page

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/ChartInstructions.css
+++ b/protx-client/src/components/ProTx/components/charts/ChartInstructions.css
@@ -17,12 +17,21 @@
   border-top: 1px solid var(--color-gray-dark);
   padding: 1rem 0 0;
 }
+.report-instructions-condensed {
+  margin: 2rem 1.5rem;
+  border-top: 1px solid var(--color-gray-dark);
+  padding: 0rem 0 0;
+}
 .report-instructions-title {
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-heavy);
 }
 .report-instructions-subtitle {
   font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-heavy);
+}
+.report-instructions-subtitle-condensed {
+  font-size: var(--font-size-normal);
   font-weight: var(--font-weight-heavy);
 }
 .report-instructions-description {
@@ -33,6 +42,11 @@
 .report-instructions-steps-group * {
   padding: 0.1rem 0;
   font-size: var(--font-size-normal);
+  font-weight: var(--font-weight-light);
+}
+.report-instructions-steps-group-condensed * {
+  padding: 0.1rem 0;
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-light);
 }
 .report-instructions-steps-group {

--- a/protx-client/src/components/ProTx/components/charts/ChartInstructions.jsx
+++ b/protx-client/src/components/ProTx/components/charts/ChartInstructions.jsx
@@ -9,6 +9,7 @@ function ChartInstructions({ currentReportType }) {
     type: '',
     title: 'Reporting Tool Instructions',
     description: 'Description of the selected reporting tool.',
+    condensed: false,
     selections: {
       subtitle: 'Using the Reporting Tool',
       steps: [
@@ -101,6 +102,7 @@ function ChartInstructions({ currentReportType }) {
     instructions.type = 'analytics';
     instructions.title = '';
     instructions.description = '';
+    instructions.condensed = true;
     instructions.selections.subtitle = 'Using the Analytics Reporting Tool';
     // instructions.selections.steps = [
     //   'Select a geographic region type from the Area dropdown menu (located above the map).',
@@ -150,15 +152,15 @@ function ChartInstructions({ currentReportType }) {
   }
 
   return (
-    <div className="report-instructions">
+    <div className={instructions.condensed ? "report-instructions-condensed" : "report-instructions"}>
       <div className="report-instructions-title">{instructions.title}</div>
       <div className="report-instructions-description">
         {instructions.description}
       </div>
-      <div className="report-instructions-subtitle">
+      <div className={instructions.condensed ? "report-instructions-subtitle-condensed" : "report-instructions-subtitle"}>
         {instructions.selections.subtitle}
       </div>
-      <div className="report-instructions-steps-group">
+      <div className={instructions.condensed ? "report-instructions-steps-group-condensed" : "report-instructions-steps-group"}>
         <ul className="report-instructions-steps">
           {/*
           {instructions.selections.steps.map(step => (

--- a/protx-client/src/components/ProTx/components/charts/MainPlot.css
+++ b/protx-client/src/components/ProTx/components/charts/MainPlot.css
@@ -14,5 +14,5 @@
   font-family: var(--font-type-roboto-condensed);
 }
 .main-plot {
-  margin: 0vh 1vw 0vh 1vw;
+  margin: 0vh 1vw;
 }

--- a/protx-client/src/components/ProTx/components/charts/MainPlot.css
+++ b/protx-client/src/components/ProTx/components/charts/MainPlot.css
@@ -14,5 +14,5 @@
   font-family: var(--font-type-roboto-condensed);
 }
 .main-plot {
-  margin: 1vh 1vw 3.7vh;
+  margin: 0vh 1vw 0vh 1vw;
 }

--- a/protx/utils/analytics.py
+++ b/protx/utils/analytics.py
@@ -58,7 +58,7 @@ def get_distribution_prediction_plot(data, geoid=None):
                       xbins=go.histogram.XBins(size=50)
                       )
     fig.update_layout(
-        height=300,
+        height=250,
         xaxis_title="<b><i>Predicted Number of Cases per 100K Persons</b><i>",
         yaxis_title="<b><i>Frequency</i></b>",
         font=dict(size=13, color="Black",  family="Roboto"),


### PR DESCRIPTION
## Overview: ##
Adjust margins, font size, and chart size for analytics

## Related Jira tickets: ##

* [COOKS-337](https://jira.tacc.utexas.edu/browse/COOKS-337)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to https://cep.test/protx/dash/analytics
2. Prior to clicking on the map and note the smaller margins, the smaller font size for the instructions, and the smaller plot. Hopefully everything should fit (i.e. no scroll needed when viewed on macbook).
3. Click on the map and note the smaller plot on the right. Everything should just barely fit.

## UI Photos:
**Before**
<img width="1671" alt="Screen Shot 2022-10-24 at 3 22 48 PM" src="https://user-images.githubusercontent.com/79928051/197621761-d473aba0-7850-4418-9920-40ea5a8e22f1.png">
<img width="1674" alt="Screen Shot 2022-10-24 at 3 24 23 PM" src="https://user-images.githubusercontent.com/79928051/197621885-301b42c6-511c-43d8-be75-fd039d105ba7.png">

**After**
<img width="1670" alt="Screen Shot 2022-10-24 at 3 25 27 PM" src="https://user-images.githubusercontent.com/79928051/197622084-5b8c80d5-fe3f-4efb-9ac6-bb4c6a7fc6bc.png">
<img width="1671" alt="Screen Shot 2022-10-24 at 3 26 21 PM" src="https://user-images.githubusercontent.com/79928051/197622199-b778f896-742a-4619-b20f-46cb5ed1e5dc.png">

## Notes: ##
