### PR TITLE
task/COOKS-375: rework changing between maltreatment/analytics/demographics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,42 +48,26 @@ Get access to Django CMS, run `docker exec -it core_portal_cms /bin/bash` and th
 python3 manage.py createsuperuser
 ```
 
-In Django CMS admin (i.e. https://cep.test/admin/`), you need to create three pages (using three snippets).
+In Django CMS admin (i.e. https://cep.test/admin/`), you need to create single page page (using a snippet).
 
 
-The iframe snippets that have the following markup:
-
-```
-<body style="margin:0px;padding:0px;overflow:hidden">
-    <div style="position:relative;width:100vw;height:100vh;">
-        <iframe src="https://cep.test/protx/dash/demographics" frameborder="0" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" width="100%" height="100%"></iframe>
-    </div>
-</body>
-```
+The iframe snippet has the following markup:
 
 ```
 <body style="margin:0px;padding:0px;overflow:hidden">
     <div style="position:relative;width:100vw;height:100vh;">
-        <iframe src="https://cep.test/protx/dash/maltreatment" frameborder="0" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" width="100%" height="100%"></iframe>
-    </div>
-</body>
-```
-
-```
-<body style="margin:0px;padding:0px;overflow:hidden">
-    <div style="position:relative;width:100vw;height:100vh;">
-        <iframe src="https://cep.test/protx/dash/analytics" frameborder="0" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" width="100%" height="100%"></iframe>
+        <iframe src="https://cep.test/protx/dash/" frameborder="0" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" width="100%" height="100%"></iframe>
     </div>
 </body>
 ```
 
 To create these pages/snippets:
 * Login to CMS Admin > Snippets
-* Add Snippet > [Paste in that code and name it (ex. demographics)] > Save Snippet
+* Add Snippet > [Paste in that code and name it "Data and Analysis"] > Save Snippet
 * Navigate to CMS Admin > Pages
-* Add Page (ex. demographics)
+* Add Page (ex. "Data and Analysis")
 * In the new Page, add a Text element (in the structure view)
-* Edit the new Text Element, select “Snippet” from the CMS dropdown options, and choose the “demographics” snippet you created.
+* Edit the new Text Element, select “Snippet” from the CMS dropdown options, and choose the “Data and Analysis” snippet you created.
 * Save and publish the Page.
 * Note: Go into the Continue Editing (Advanced Settings) and change the template from nearest ancestor to Full Width
 * The page will now link to the container route.
@@ -96,7 +80,7 @@ npm ci
 npm run dev
 ```
 
-Then go to either `https://cep.test/`, `https://cep.test/workbench`, `https://cep.test/protx/dash/maltreatment`, `https://cep.test/protx/dash/demographics` or `https://cep.test/protx/dash/analytics`
+Then go to either `https://cep.test/`, `https://cep.test/workbench`, `https://cep.test/protx/dash/`
 
 ## Testing
 

--- a/protx-client/src/components/ProTx/components/charts/MainChart.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.jsx
@@ -49,7 +49,7 @@ function MainChart({ data, showInstructions }) {
 
   useEffect(() => {
     if (
-      selection.type === 'demographics' &&
+      selection.type === 'observedFeatures' &&
       selection.selectedGeographicFeature
     ) {
       dispatch({
@@ -108,7 +108,7 @@ function MainChart({ data, showInstructions }) {
   }
 
   // DEMOGRAPHICS PLOT.
-  if (selection.type === 'demographics') {
+  if (selection.type === 'observedFeatures') {
     if (selection.selectedGeographicFeature && selection.observedFeature) {
       if (protxDemographicsDistribution.error) {
         return (

--- a/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
@@ -123,13 +123,13 @@ function DisplaySelectors({ downloadResources }) {
   return (
     <div className={styles['display-selectors']}>
       <div className={styles['control']}>
-        <span className={styles['label']}>Type</span>
+        <span className={styles['label']}>Report</span>
         <DropdownSelector
           value={selection.type}
           onChange={(event) => setType(event.target.value)}
         >
-          <optgroup label="Select Type">
-            <option value="maltreatment">Maltreatment</option>
+          <optgroup label="Select Report">
+            <option value="maltreatment">Child Maltreatment</option>
             <option value="observedFeatures">Demographics</option>
             <option value="analytics">Analytics</option>
           </optgroup>

--- a/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
+++ b/protx-client/src/components/ProTx/components/dashboard/DisplaySelectors.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { DropdownSelector } from '_common';
 import { Button } from 'reactstrap';
 import MaltreatmentSelector from './MaltreatmentSelector';
-import { OBSERVED_FEATURES_TOP_FIELDS, SUPPORTED_YEARS } from '../data/meta';
+import { SUPPORTED_YEARS } from '../data/meta';
 import styles from './DisplaySelectors.module.scss';
 
 /* Radio buttons for types of values to display in dropdown (see COOKS-110 for next steps). */
@@ -62,66 +62,83 @@ RateSelector.propTypes = {
 /**
  * Selectors (i.e. dropdowns) to allow users to select what to display on maps/charts
  *
- * Customizations:
- * - if `setGeography` or `setYear` are not set then the associated dropdown is disabled
- * - if 'limitToTopObservedFeatureFields' then a limited set of demographic data is selectable
- *    (and user can't switch between value types like between percent/total)
  * Note:
  * Maltreatment data is available at the county level.
  * Demographic Features only has 2019 data.
  *
  */
-function DisplaySelectors({
-  mapType,
-  geography,
-  maltreatmentTypes,
-  observedFeature,
-  year,
-  unit,
-  selectedGeographicFeature,
-  setGeography,
-  setMaltreatmentTypes,
-  setObservedFeature,
-  setYear,
-  setUnit,
-  limitToTopObservedFeatureFields,
-  downloadResources,
-}) {
-  const disableGeography = mapType === 'maltreatment' || setGeography === null;
-  const disabledYear = mapType === 'observedFeatures' || setYear == null;
-  const valueLabelRadioBtn0 = 'Percentages';
-  const valueLabelRadioBtn1 =
-    mapType === 'maltreatment' ? 'Rate per 100K children' : 'Totals';
-  const valueRadioBtn0 = 'percent';
-  const valueRadioBtn1 =
-    mapType === 'maltreatment' ? 'rate_per_100k_under17' : 'count';
+function DisplaySelectors({ downloadResources }) {
+  const dispatch = useDispatch();
+  const selection = useSelector((state) => state.protxSelection);
   const display = useSelector((state) => state.protx.data.display);
 
-  const changeUnit = (newUnit) => {
-    if (mapType === 'observedFeatures') {
-      // check to see if we also need to switch the variable if it doesn't a count or percentage
-      // that would be needed.
-      const current = display.variables.find((f) => f.NAME === observedFeature);
-      if (newUnit && current.DISPLAY_DEMOGRAPHIC_RATE === 0) {
-        setObservedFeature(
-          display.variables.find((f) => f.DISPLAY_DEMOGRAPHIC_RATE === 1).NAME
-        );
-      }
-      if (!newUnit && current.DISPLAY_DEMOGRAPHIC_COUNT === 0) {
-        setObservedFeature(
-          display.variables.find((f) => f.DISPLAY_DEMOGRAPHIC_COUNT === 1).NAME
-        );
-      }
-    }
-    setUnit(newUnit);
+  const setType = (selectedType) => {
+    dispatch({
+      type: 'PROTX_CONFIG/SET_TYPE',
+      payload: { type: selectedType, displayData: display },
+    });
   };
+  const setYear = (year) => {
+    dispatch({
+      type: 'PROTX_CONFIG/SET_YEAR',
+      payload: year,
+    });
+  };
+  const setMaltreatmentTypes = (maltreatmentTypes) => {
+    dispatch({
+      type: 'PROTX_CONFIG/SET_SELECTED_MALTREATMENT_TYPES',
+      payload: maltreatmentTypes,
+    });
+  };
+  const setObservedFeature = (observedFeature) => {
+    dispatch({
+      type: 'PROTX_CONFIG/SET_OBSERVED_FEATURE',
+      payload: observedFeature,
+    });
+  };
+  const setUnit = (newUnit) => {
+    dispatch({
+      type: 'PROTX_CONFIG/SET_UNIT',
+      payload: { unit: newUnit, displayData: display },
+    });
+  };
+  const setGeography = (newGeography) => {
+    dispatch({
+      type: 'PROTX_CONFIG/SET_GEOGRAPHY',
+      payload: newGeography,
+    });
+  };
+
+  const demographicsOrMaltreatment =
+    selection.type === 'maltreatment' || selection.type === 'observedFeatures';
+  const disableGeography = selection.type !== 'observedFeatures';
+  const disabledYear = selection.type === 'observedFeatures';
+  const valueLabelRadioBtn0 = 'Percentages';
+  const valueLabelRadioBtn1 =
+    selection.type === 'maltreatment' ? 'Rate per 100K children' : 'Totals';
+  const valueRadioBtn0 = 'percent';
+  const valueRadioBtn1 =
+    selection.type === 'maltreatment' ? 'rate_per_100k_under17' : 'count';
 
   return (
     <div className={styles['display-selectors']}>
       <div className={styles['control']}>
+        <span className={styles['label']}>Type</span>
+        <DropdownSelector
+          value={selection.type}
+          onChange={(event) => setType(event.target.value)}
+        >
+          <optgroup label="Select Type">
+            <option value="maltreatment">Maltreatment</option>
+            <option value="observedFeatures">Demographics</option>
+            <option value="analytics">Analytics</option>
+          </optgroup>
+        </DropdownSelector>
+      </div>
+      <div className={styles['control']}>
         <span className={styles['label']}>Area</span>
         <DropdownSelector
-          value={geography}
+          value={selection.geography}
           onChange={(event) => setGeography(event.target.value)}
           disabled={disableGeography}
         >
@@ -132,36 +149,36 @@ function DisplaySelectors({
           </optgroup>
         </DropdownSelector>
       </div>
-      {setUnit && (
+      {demographicsOrMaltreatment && (
         <div className={styles['control']}>
           <span className={styles['label']}>Value</span>
           <RateSelector
-            value={unit}
+            value={selection.unit}
             valueLabelRadioBtn0={valueLabelRadioBtn0}
             valueLabelRadioBtn1={valueLabelRadioBtn1}
             valueRadioBtn0={valueRadioBtn0}
             valueRadioBtn1={valueRadioBtn1}
-            setValue={changeUnit}
+            setValue={setUnit}
           />
         </div>
       )}
-      {mapType === 'maltreatment' && (
+      {selection.type === 'maltreatment' && (
         <div className={styles['control']}>
           <span className={styles['label']}>Type</span>
           <MaltreatmentSelector
-            unit={unit}
+            unit={selection.unit}
             variables={display.variables}
-            selectedTypes={maltreatmentTypes}
+            selectedTypes={selection.maltreatmentTypes}
             setSelectedTypes={setMaltreatmentTypes}
           />
         </div>
       )}
-      {(mapType === 'observedFeatures' || mapType === 'predictiveFeatures') && (
+      {selection.type === 'observedFeatures' && (
         <>
           <div className={styles['control']}>
             <span className={styles['label']}>Demographic</span>
             <DropdownSelector
-              value={observedFeature}
+              value={selection.observedFeature}
               onChange={(event) => setObservedFeature(event.target.value)}
             >
               <optgroup label="Select demographic feature">
@@ -176,13 +193,16 @@ function DisplaySelectors({
                     return 0;
                   })
                   .filter((f) => {
-                    if (limitToTopObservedFeatureFields) {
-                      return OBSERVED_FEATURES_TOP_FIELDS.includes(f.NAME);
-                    }
-                    if (unit === 'percent' && f.DISPLAY_DEMOGRAPHIC_RATE) {
+                    if (
+                      selection.unit === 'percent' &&
+                      f.DISPLAY_DEMOGRAPHIC_RATE
+                    ) {
                       return true;
                     }
-                    if (unit === 'count' && f.DISPLAY_DEMOGRAPHIC_COUNT) {
+                    if (
+                      selection.unit === 'count' &&
+                      f.DISPLAY_DEMOGRAPHIC_COUNT
+                    ) {
                       return true;
                     }
                     return false;
@@ -197,11 +217,11 @@ function DisplaySelectors({
           </div>
         </>
       )}
-      {mapType !== 'analytics' && (
+      {selection.type !== 'analytics' && (
         <div className={styles['control']}>
           <span className={styles['label']}>Years</span>
           <DropdownSelector
-            value={year}
+            value={selection.year}
             onChange={(event) => setYear(event.target.value)}
             disabled={disabledYear}
           >
@@ -214,7 +234,7 @@ function DisplaySelectors({
           </DropdownSelector>
         </div>
       )}
-      {selectedGeographicFeature && (
+      {selection.selectedGeographicFeature && (
         <Button
           onClick={downloadResources}
           color="primary"
@@ -230,27 +250,7 @@ function DisplaySelectors({
 }
 
 DisplaySelectors.propTypes = {
-  mapType: PropTypes.string.isRequired,
-  geography: PropTypes.string.isRequired,
-  maltreatmentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
-  observedFeature: PropTypes.string.isRequired,
-  year: PropTypes.string.isRequired,
-  unit: PropTypes.string.isRequired,
-  selectedGeographicFeature: PropTypes.string.isRequired,
-  setGeography: PropTypes.func,
-  setMaltreatmentTypes: PropTypes.func.isRequired,
-  setObservedFeature: PropTypes.func.isRequired,
-  setYear: PropTypes.func,
-  setUnit: PropTypes.func,
-  limitToTopObservedFeatureFields: PropTypes.bool,
   downloadResources: PropTypes.func.isRequired,
-};
-
-DisplaySelectors.defaultProps = {
-  setGeography: null,
-  setYear: null,
-  setUnit: null,
-  limitToTopObservedFeatureFields: false,
 };
 
 export default DisplaySelectors;

--- a/protx-client/src/components/ProTx/components/data/meta.js
+++ b/protx-client/src/components/ProTx/components/data/meta.js
@@ -11,16 +11,6 @@ export const SUPPORTED_YEARS = [
   '2011',
 ];
 
-export const OBSERVED_FEATURES_TOP_FIELDS = [
-  'SNGPNT',
-  'POV',
-  'PCI',
-  'AGE17',
-  'NOHSDP',
-  'GROUPQ',
-  'CROWD',
-];
-
 // TOOO: we should correct vector files to all be the same thing (GEOID)
 export const GEOID_KEY = {
   cbsa: 'GEOID_left',
@@ -30,20 +20,3 @@ export const GEOID_KEY = {
   urban_area: 'GEOID10',
   zcta: 'GEOID10',
 };
-
-/**
- * Define array of category codes.
- */
-export const CATEGORY_CODES = [
-  'ABAN',
-  'EMAB',
-  'LBTR',
-  'MDNG',
-  'NSUP',
-  'PHAB',
-  'PHNG',
-  'RAPR',
-  'SXAB',
-  'SXTR',
-  'NA',
-];

--- a/protx-client/src/redux/reducers/configuration.js
+++ b/protx-client/src/redux/reducers/configuration.js
@@ -13,13 +13,14 @@ const PRESELECTED_MALTREATMENT_CATEGORIES = [
 
 const DEFAULT_YEAR = '2020';
 
+/* initial state on load is demographics/observedFeatures */
 export const initialState = {
-  type: 'maltreatment',
+  type: 'observedFeatures',
   geography: 'county',
   maltreatmentTypes: PRESELECTED_MALTREATMENT_CATEGORIES,
   observedFeature: 'AGE17',
   year: DEFAULT_YEAR,
-  unit: 'rate_per_100k_under17',
+  unit: 'percent',
   selectedGeographicFeature: '',
 };
 

--- a/protx-client/src/redux/reducers/configuration.js
+++ b/protx-client/src/redux/reducers/configuration.js
@@ -1,0 +1,144 @@
+const PRESELECTED_MALTREATMENT_CATEGORIES = [
+  'ABAN',
+  'EMAB',
+  'LBTR',
+  'MDNG',
+  'NSUP',
+  'PHAB',
+  'PHNG',
+  'RAPR',
+  'SXAB',
+  'SXTR',
+];
+
+const DEFAULT_YEAR = '2020';
+
+export const initialState = {
+  type: 'maltreatment',
+  geography: 'county',
+  maltreatmentTypes: PRESELECTED_MALTREATMENT_CATEGORIES,
+  observedFeature: 'AGE17',
+  year: DEFAULT_YEAR,
+  unit: 'rate_per_100k_under17',
+  selectedGeographicFeature: '',
+};
+
+function transitionToNewType(state, newType, displayData) {
+  if (newType === state.type) {
+    return state;
+  } else {
+    switch (newType) {
+      case 'maltreatment':
+        return {
+          ...state,
+          type: newType,
+          geography: 'county',
+          unit: state.unit === 'count' ? 'rate_per_100k_under17' : state.unit, // maltreatment can be 'percent' or 'rate_per_100k_under17'
+          selectedGeographicFeature:
+            state.geography === 'county' ? state.selectedGeographicFeature : '', // reset if not a selected county
+        };
+      case 'observedFeatures':
+        const updatedUnit =
+          state.unit === 'rate_per_100k_under17' ? 'count' : state.unit; // demographics can be 'percent' or 'count'
+        return {
+          ...state,
+          type: newType,
+          year: DEFAULT_YEAR, // show only single year of demographics //TODOroute confirm
+          unit: updatedUnit,
+          observedFeature: getCorrectSelectedObservedFeature(
+            state.observedFeature,
+            updatedUnit,
+            displayData
+          ),
+        };
+      case 'analytics':
+        return {
+          ...state,
+          type: newType,
+          year: DEFAULT_YEAR,
+          geography: 'county',
+          selectedGeographicFeature:
+            state.geography === 'county' ? state.selectedGeographicFeature : '', // reset if not a selected county
+        };
+      default:
+        console.error('Switching to unsupported type');
+        return state;
+    }
+  }
+}
+
+function getCorrectSelectedObservedFeature(
+  currentObservedFeature,
+  currentUnit,
+  displayData
+) {
+  // check to see if we also need to switch the variable if it doesn't have a a count or percentage
+  // that would be needed.
+  const currentFeature = displayData.variables.find(
+    (f) => f.NAME === currentObservedFeature
+  );
+  if (currentUnit === 'percent' && !currentFeature.DISPLAY_DEMOGRAPHIC_RATE) {
+    // switch to another variable that has DISPLAY_DEMOGRAPHIC_RATE as true
+    return displayData.variables.find((f) => f.DISPLAY_DEMOGRAPHIC_RATE).NAME;
+  } else if (
+    currentUnit === 'count' &&
+    !currentFeature.DISPLAY_DEMOGRAPHIC_COUNT
+  ) {
+    // switch to another variable that has DISPLAY_DEMOGRAPHIC_COUNT as true
+    return displayData.variables.find((f) => f.DISPLAY_DEMOGRAPHIC_COUNT).NAME;
+  } else {
+    return currentObservedFeature;
+  }
+}
+
+export function protxSelection(state = initialState, action) {
+  switch (action.type) {
+    case 'PROTX_CONFIG/SET_TYPE':
+      return transitionToNewType(
+        state,
+        action.payload.type,
+        action.payload.displayData
+      );
+    case 'PROTX_CONFIG/SET_SELECTED_MALTREATMENT_TYPES':
+      return {
+        ...state,
+        maltreatmentTypes: action.payload,
+      };
+    case 'PROTX_CONFIG/SET_OBSERVED_FEATURE':
+      return {
+        ...state,
+        observedFeature: action.payload,
+      };
+    case 'PROTX_CONFIG/SET_GEOGRAPHY':
+      return {
+        ...state,
+        geography: action.payload,
+        selectedGeographicFeature: '',
+      };
+    case 'PROTX_CONFIG/SET_YEAR':
+      return {
+        ...state,
+        year: action.payload,
+      };
+    case 'PROTX_CONFIG/SET_UNIT':
+      const newState = {
+        ...state,
+        unit: action.payload.unit,
+      };
+      if (state.type === 'observedFeatures') {
+        newState.observedFeature = getCorrectSelectedObservedFeature(
+          newState.observedFeature,
+          newState.unit,
+          action.payload.displayData
+        );
+      }
+      return newState;
+    case 'PROTX_CONFIG/SET_SELECTED_GEOGRAPHIC_FEATURE':
+      return {
+        ...state,
+        selectedGeographicFeature: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/protx-client/src/redux/reducers/index.js
+++ b/protx-client/src/redux/reducers/index.js
@@ -6,9 +6,11 @@ import {
   protxAnalytics,
   protxAnalyticsStatewideDistribution,
 } from './protx.reducers';
+import { protxSelection } from './configuration';
 
 export default combineReducers({
   protx,
+  protxSelection,
   protxDemographicsDistribution,
   protxMaltreatmentDistribution,
   protxAnalytics,

--- a/protx/app.py
+++ b/protx/app.py
@@ -15,7 +15,7 @@ api = Api(app, title="ProTx API", version="1.0", description="Protx")
 api.add_namespace(protx_api, path="/protx/api")
 
 
-@app.route("/protx/dash/<path:path>")
+@app.route("/protx/dash/")
 @onboarded_user_setup_complete(redirect_path='/protx/onboarding')  # redirect not to CEP as we are in iframe
 def index(path):
     return render_template(template)

--- a/protx/app.py
+++ b/protx/app.py
@@ -17,7 +17,7 @@ api.add_namespace(protx_api, path="/protx/api")
 
 @app.route("/protx/dash/")
 @onboarded_user_setup_complete(redirect_path='/protx/onboarding')  # redirect not to CEP as we are in iframe
-def index(path):
+def index():
     return render_template(template)
 
 

--- a/protx/tests/app_test.py
+++ b/protx/tests/app_test.py
@@ -1,10 +1,10 @@
 def test_dash_analytics(test_client, core_api_workbench_request):
-    response = test_client.get('/protx/dash/analytics')
+    response = test_client.get('/protx/dash/')
     assert response.status_code == 200
 
 
 def test_dash_analytics_redirect_with_setup_complete_false(test_client, core_api_workbench_request_setup_complete_false):
-    response = test_client.get('/protx/dash/analytics')
+    response = test_client.get('/protx/dash/')
     assert response.status_code == 302
     assert response.location == 'http://localhost//protx/onboarding'
 


### PR DESCRIPTION
## Overview: ##

This PR reworks the user changing between maltreatment/analytics/demographics:
* Added element for the user to change between maltreatment/analytics/demographics
* added redux state and related sagas for current selection (i.e. year, maltreatment, etc) - [COOKS-55](https://jira.tacc.utexas.edu/browse/COOKS-55)
* fixed bug we had seen when switching between percentages and totals for a demographic feature that shouldn't be displayed. (in the bug you would see a blank map; this can be seen on prod)

## Related Jira tickets: ##

* [COOKS-375](https://jira.tacc.utexas.edu/browse/COOKS-375)
* [COOKS-55](https://jira.tacc.utexas.edu/browse/COOKS-55)


## Testing Steps: ##
1. Go to [ /protx/dash/](https://cep.test/protx/dash/)
2. Switch between maltreatment, analytics, demographics
3. click on different counties and switch between reports to confirm your selection, e.g year, county, (if possible) stays between reports. 

Review README
1) check if README makes sense

## Notes: ##

- [x] clarify UI element to switch between analytics/demographics/maltreatment .  See John's mockup.  **update: keep as currently in  pr
- [x] clarify route (i.e. dropping routes now but easy to add with q**uery params that dispatch saga actions)
- [x] add unit tests for configuration.js reducer. **Update: added follow on isssue: https://jira.tacc.utexas.edu/browse/COOKS-385)**
- [x] clarify if we want a separate state for unit (percent/count etc) for demographics vs maltreatment (we are using the same state for this at the moment). same applies for year  **update: keep as currently in  pr**
