### PR TITLE
Updated the poetry installer curl command in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y curl
 RUN mkdir /app
 WORKDIR /app/protx
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 RUN poetry config virtualenvs.create false
 


### PR DESCRIPTION
Updated the poetry installer curl command in the Dockerfile to match core-portal and mitigate the 404 error from the old poetry repo that was being used.

## Overview: ##

Old poetry installation script is no longer at that URL, throws a 404.
Updated to align with core-portal usage.

## Related Jira tickets: ##

* None

## Summary of Changes: ##

* Updated the curl command to use the correct poetry repo for the installation script step.

## Testing Steps: ##

1. Build the project successfully.

## UI Photos:

* N/A

## Notes: ##

* N/A