### PR TITLE
Task/cooks 348 fix header line

### DIFF
--- a/protx-client/src/components/ProTx/components/charts/AnalyticsPredictiveTable.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsPredictiveTable.jsx
@@ -77,7 +77,7 @@ function AnalyticsPredictiveTable({ geography, selectedGeographicFeature }) {
     return (
       <div className="feature-table-chart-title">
         {' '}
-        Top Three Maltreatment Factors for {countyName} County
+        Top Factors for {countyName} County
         <span className="feature-table-chart-subtitle">({chartSubtitle})</span>
       </div>
     );

--- a/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
@@ -80,22 +80,20 @@ function AnalyticsStateDistribution({ geography, selectedGeographicFeature }) {
   );
 
   return (
-    <>
-      <div className="plot-details">
-        <div className="plot-details-section">
-        <div className="plot-details-section-selected">
-          <div className='feature-table-chart-title'>
-            <span className="plot-details-section-selected-label">
-          Definition of Risk Levels</span>
-          <span className="main-chart-title-text-annotation">(Figure 1)</span></div>
+    <div className="maltreatment-types-plot-layout">
+      <div className="feature-table">
+        <div className="feature-table-chart-selection">
+          <div className="feature-table-chart-title">
+            Definition of Risk Levels
+            <span className="feature-table-chart-subtitle">(Figure 1)</span>
+          </div>
         </div>
-        </div>
-    <MainPlot plotState={chartData.data} />
-    <FigureCaption label={'Figure 1.'} className={'chart-annotation'}>
-      {plotCaptionJSX}
-    </FigureCaption>
-  </div>
-</>
+      </div>
+      <MainPlot plotState={chartData.data} />
+      <FigureCaption label={'Figure 1.'} className={'chart-annotation'}>
+        {plotCaptionJSX}
+      </FigureCaption>
+    </div>
 
   );
 }

--- a/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
@@ -84,9 +84,10 @@ function AnalyticsStateDistribution({ geography, selectedGeographicFeature }) {
       <div className="plot-details">
         <div className="plot-details-section">
         <div className="plot-details-section-selected">
+          <div className='feature-table-chart-title'>
             <span className="plot-details-section-selected-label">
           Definition of Risk Levels</span>
-          <span className="plot-details-section-selected-annotation"> (Figure 1)</span>
+          <span className="main-chart-title-text-annotation">(Figure 1)</span></div>
         </div>
         </div>
     <MainPlot plotState={chartData.data} />

--- a/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
+++ b/protx-client/src/components/ProTx/components/charts/AnalyticsStateDistribution.jsx
@@ -80,20 +80,22 @@ function AnalyticsStateDistribution({ geography, selectedGeographicFeature }) {
   );
 
   return (
-    <div className="maltreatment-types-plot-layout">
-      <div className="feature-table">
-        <div className="feature-table-chart-selection">
-          <div className="feature-table-chart-title">
-            Definition of Risk Levels
-            <span className="feature-table-chart-subtitle">(Figure 1)</span>
-          </div>
+    <>
+      <div className="plot-details">
+        <div className="plot-details-section">
+        <div className="plot-details-section-selected">
+            <span className="plot-details-section-selected-label">
+          Definition of Risk Levels</span>
+          <span className="plot-details-section-selected-annotation"> (Figure 1)</span>
         </div>
-      </div>
-      <MainPlot plotState={chartData.data} />
-      <FigureCaption label={'Figure 1.'} className={'chart-annotation'}>
-        {plotCaptionJSX}
-      </FigureCaption>
-    </div>
+        </div>
+    <MainPlot plotState={chartData.data} />
+    <FigureCaption label={'Figure 1.'} className={'chart-annotation'}>
+      {plotCaptionJSX}
+    </FigureCaption>
+  </div>
+</>
+
   );
 }
 

--- a/protx-client/src/components/ProTx/components/charts/MainChart.css
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.css
@@ -1,1 +1,18 @@
 /* MAIN CHART */
+.main-chart{
+
+  }
+.main-chart-title {
+    min-height: 3vh;
+    margin: 0.5vh 1vw;
+    display: flex;
+    border-bottom: 1px solid var(--color-gray-very-dark);
+    font-size: calc(var(--font-size-normal) * 1.3);
+    font-weight: var(--font-weight-heavy);
+    text-align: center;
+  }
+.main-chart-title-text {
+    display:inline;
+    width: 100%;
+
+}

--- a/protx-client/src/components/ProTx/components/charts/MainChart.css
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.css
@@ -16,3 +16,10 @@
     width: 100%;
 
 }
+.main-chart-title-text-annotation {  
+  margin: 0 0 0 0.5vw;
+  font-style: oblique;
+  color: var(--color-gray);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-heavy);
+}

--- a/protx-client/src/components/ProTx/components/charts/MainChart.css
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.css
@@ -16,10 +16,3 @@
     width: 100%;
 
 }
-.main-chart-title-text-annotation {  
-  margin: 0 0 0 0.5vw;
-  font-style: oblique;
-  color: var(--color-gray);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-heavy);
-}

--- a/protx-client/src/components/ProTx/components/charts/MainChart.jsx
+++ b/protx-client/src/components/ProTx/components/charts/MainChart.jsx
@@ -79,14 +79,11 @@ function MainChart({ data, showInstructions }) {
         )}  County`
       : 'Texas Statewide Data';
     return (
-      <div className="analytics-types-plot-layout">
-        <div className="plot-details-section">
-          <div className="plot-details-section-selected">
-            <span className="plot-details-section-selected-value">
-              {plotDetailSectionTitle}
-            </span>
-          </div>
-        </div>
+
+      <div className="main-chart">
+        <span className='main-chart-title'>
+          <span className='main-chart-title-text'>
+              {plotDetailSectionTitle}</span></span>
         <AnalyticsStateDistribution
           geography={selection.geography}
           selectedGeographicFeature={selection.selectedGeographicFeature}
@@ -96,7 +93,7 @@ function MainChart({ data, showInstructions }) {
             geography={selection.geography}
             selectedGeographicFeature={selection.selectedGeographicFeature}
           />
-        )}
+        )}      
 
         <ChartInstructions
           currentReportType={

--- a/protx-client/src/components/ProTx/components/charts/PlotDetails.css
+++ b/protx-client/src/components/ProTx/components/charts/PlotDetails.css
@@ -21,6 +21,10 @@
   font-size: calc(var(--font-size-normal) * 1.3);
   font-weight: var(--font-weight-heavy);
 }
+.plot-details-section-selected-annotation {
+  font-weight: var(--font-weight-light);
+  font-style: italic;
+}
 .plot-details-section-selected-value-list {
   margin-left: 1rem;
   font-size: var(--font-size-normal);


### PR DESCRIPTION
## Overview: ##
Adjusted header line to not go across the whole page. Removed wording from Maltreatment table that was incorrect

## Related Jira tickets: ##

* [COOKS-348](https://jira.tacc.utexas.edu/browse/COOKS-348)

## Summary of Changes: ##
Adjuste line under county or Texas Statewide Data title for Analytics to not go across the whole section to end of page.
Changed Maltreatment table on analytics page to reflect the wording Tracy asked for


## Testing Steps: ##
1. Go to cep.test and go to Analytics
2. Make sure line under _____ County or Texas Statewide Data lines up with the rest of the chart section on the right

## UI Photos:
![Screen Shot 2023-02-20 at 12 29 03 PM](https://user-images.githubusercontent.com/96220951/220178257-b884eb70-a0ef-46c2-8619-4f286ab8d2ac.png)
![Screen Shot 2023-02-20 at 12 29 17 PM](https://user-images.githubusercontent.com/96220951/220178285-2d41c872-8603-45d0-be52-72a360b4a53c.png)


## Notes: ##
