### PR TITLE
Bump runner CI to use ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Server_Side_Unit_Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -41,7 +41,7 @@ jobs:
           USE_DEV_CLIENT: True
 
   Server_Side_Linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -72,7 +72,7 @@ jobs:
           poetry run flake8
 
   Client_Side_Unit_Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js for use with actions
@@ -97,7 +97,7 @@ jobs:
           npm run test
 
   Client_Side_Linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js for use with actions


### PR DESCRIPTION
## Overview: ##

Technically, this was still working as not on 18.04 but bumping so that all repos have latest.

>  Ubuntu 18.04 runner is deprecated ( https://github.com/actions/runner-images/pull/7388 ) as noted in [WG-29](https://jira.tacc.utexas.edu/browse/WG-29).  Bumping runner to ubuntu-latest (22.04).

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-29](https://jira.tacc.utexas.edu/browse/WG-29)

## Testing Steps: ##
1. Check that CI is running
